### PR TITLE
add pyyaml to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     url="http://enjoy-digital.fr",
     download_url="https://github.com/enjoy-digital/litepcie",
     test_suite="test",
+    install_requires=['pyyaml'],
     license="BSD",
     platforms=["Any"],
     keywords="HDL ASIC FPGA hardware design",


### PR DESCRIPTION
This way not only travis config knows about the dependency and 'python setup.py test' can be used directly.