### PR TITLE
software: include cdev.h

### DIFF
--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -23,6 +23,7 @@
 #include <linux/slab.h>
 #include <linux/pci.h>
 #include <linux/pci_regs.h>
+#include <linux/cdev.h>
 #include <linux/delay.h>
 #include <linux/wait.h>
 #include <linux/version.h>


### PR DESCRIPTION
cdev.h is required for cdev_init() and other calls; it was probably included through some other headers on older kernel versions, but at least on 5.4.0 it has to be added.