### PR TITLE
Improve kernel driver

### DIFF
--- a/litepcie/software/kernel/init.sh
+++ b/litepcie/software/kernel/init.sh
@@ -1,7 +1,3 @@
 #!/bin/sh
-# TODO: use udev instead
 
 insmod litepcie.ko
-
-major=$(awk '/ litepcie$/{print $1}' /proc/devices)
-mknod -m 666 /dev/litepcie0 c $major 0

--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -508,7 +508,6 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
     for(i = 0; i < PCIE_DMA_BUFFER_COUNT; i++) {
         s->dma_tx_bufs[i] = kzalloc(DMA_BUFFER_SIZE, GFP_KERNEL | GFP_DMA32);
         if (!s->dma_tx_bufs[i]) {
-            dev_err(&dev->dev, "Failed to allocate dma_tx_buf\n");
             goto fail6;
         }
         s->dma_tx_bufs_addr[i] = pci_map_single(dev, s->dma_tx_bufs[i],

--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -498,9 +498,10 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
         goto fail4;
     }
 
-    if (request_irq(dev->irq, litepcie_interrupt, IRQF_SHARED, LITEPCIE_NAME, s) < 0) {
+    if (devm_request_irq(&dev->dev, dev->irq, litepcie_interrupt, 
+                         IRQF_SHARED, LITEPCIE_NAME, s) < 0) {
         dev_err(&dev->dev, "Failed to allocate irq %d\n", dev->irq);
-        goto fail5;
+        goto fail4;
     }
 
     /* allocate DMA buffers */
@@ -542,8 +543,6 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 
  fail6:
     litepcie_end(dev, s);
-    free_irq(dev->irq, s);
- fail5:
  fail4:
     pci_iounmap(dev, s->bar0_addr);
  fail3:
@@ -587,7 +586,6 @@ static void litepcie_pci_remove(struct pci_dev *dev)
     litepcie_minor_table[s->minor] = NULL;
 
     litepcie_end(dev, s);
-    free_irq(dev->irq, s);
     pci_iounmap(dev, s->bar0_addr);
     pci_release_regions(dev);
     device_destroy(litepcie_class, MKDEV(MAJOR(litepcie_cdev), s->minor));

--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -442,7 +442,7 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
     s->dev = dev;
     pci_set_drvdata(dev, s);
 
-    ret = pci_enable_device(dev);
+    ret = pcim_enable_device(dev);
     if (ret != 0) {
         dev_err(&dev->dev, "Cannot enable device\n");
         goto fail1;
@@ -533,13 +533,11 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
     litepcie_end(dev, s);
     free_irq(dev->irq, s);
  fail5:
-    pci_disable_msi(dev);
  fail4:
     pci_iounmap(dev, s->bar0_addr);
  fail3:
     pci_release_regions(dev);
  fail2:
-    pci_disable_device(dev);
     ret = -EIO;
  fail1:
     kfree(s);
@@ -577,9 +575,7 @@ static void litepcie_pci_remove(struct pci_dev *dev)
 
     litepcie_end(dev, s);
     free_irq(dev->irq, s);
-    pci_disable_msi(dev);
     pci_iounmap(dev, s->bar0_addr);
-    pci_disable_device(dev);
     pci_release_regions(dev);
     kfree(s);
 };

--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -23,6 +23,7 @@
 #include <linux/slab.h>
 #include <linux/pci.h>
 #include <linux/pci_regs.h>
+#include <linux/cdev.h>
 #include <linux/delay.h>
 #include <linux/wait.h>
 #include <linux/version.h>


### PR DESCRIPTION
The main improvement is that class_create() / device_create() handle device node creation without manual mknod. Some smaller cleanups include the use of managed functions which do not require manual cleanup (pcim_enable_device() obsoletes pci_disable_msi and pci_disable_device,  devm_kzalloc() - free). Char devices are now created per device in probe() instead of bulk in init().