### PR TITLE
Fix kernel module unloading

### DIFF
--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -590,9 +590,10 @@ static void litepcie_pci_remove(struct pci_dev *dev)
 
     litepcie_end(dev, s);
     pci_iounmap(dev, s->bar0_addr);
-    pci_release_regions(dev);
     device_destroy(litepcie_class, MKDEV(MAJOR(litepcie_cdev), s->minor));
     cdev_del(&s->cdev_struct);
+	/* There is no need to call pci_release_regions() as it is handled
+	 * by the kernel since we used pcim_enable_device() */
 };
 
 static const struct pci_device_id litepcie_pci_ids[] = {


### PR DESCRIPTION
As per the [kernel pci documentation](https://www.kernel.org/doc/Documentation/PCI/pci.txt) `pci_release_regions()` shall be called after `pci_disable_device()`.

However the kernel module code uses the managed version `pcim_enable_device()`.
When using the managed version, `pci_release_regions()` could be called before `pci_disable_device()` because `pci_disable_device()` is called upon leaving `litepcie_pci_remove()` (as far as I understand).

Please note that I did not run into that issue with this specific driver, but while working on a similar project I had strange behavior on driver unloading and using the managed version of `pci_enable_device()` was the cause.

Finally, since I don't own any hardware (yet) I am not able to test this commit...