### PR TITLE
kernel: remove unnecessary call to pci_release_regions() on device remove

### DIFF
--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -590,7 +590,6 @@ static void litepcie_pci_remove(struct pci_dev *dev)
 
     litepcie_end(dev, s);
     pci_iounmap(dev, s->bar0_addr);
-    pci_release_regions(dev);
     device_destroy(litepcie_class, MKDEV(MAJOR(litepcie_cdev), s->minor));
     cdev_del(&s->cdev_struct);
 };


### PR DESCRIPTION
This is a follow-up to the discussion in https://github.com/enjoy-digital/litepcie/pull/26 - managed functions take care of the region release.