### PR TITLE
software: allows to cross compile driver and userspace applications

### DIFF
--- a/litepcie/software/kernel/Makefile
+++ b/litepcie/software/kernel/Makefile
@@ -1,6 +1,7 @@
 # Makefile for kernel module
 KERNEL_VERSION:=$(shell uname -r)
-KERNEL_PATH:=/lib/modules/$(KERNEL_VERSION)/build
+KERNEL_PATH?=/lib/modules/$(KERNEL_VERSION)/build
+ARCH?=$(shell uname -m)
 
 obj-m = litepcie.o
 litepcie-objs = main.o
@@ -9,8 +10,8 @@ litepcie-objs = main.o
 all: litepcie.ko
 
 litepcie.ko: main.c
-	make -C $(KERNEL_PATH) M=$(shell pwd) modules
+	make -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) modules
 
 clean:
-	make -C $(KERNEL_PATH) M=$(shell pwd) clean
+	make -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) clean
 	rm -f *~

--- a/litepcie/software/user/Makefile
+++ b/litepcie/software/user/Makefile
@@ -1,6 +1,6 @@
 CFLAGS=-O2 -Wall -g -I../kernel -MMD
 LDFLAGS=-g
-CC=gcc
+CC=$(CROSS_COMPILE)gcc
 AR=ar
 
 PROGS=litepcie_util litepcie_test


### PR DESCRIPTION
Makefile in `software/user` and `software/kernel` are written to do a native build (ie. build on machine where driver will be used).
It's not possible to cross-compile those code for embedded boards with a different architecture and kernel version using cross-toolchain (for instance built by *buildroot*).

- This PR replace `:= `by `?=`for `KERNEL_PATH` to allows users to provides an alternate linux root path
- `ARCH` is introduce, with by default current system architecture, but may be overwritten by user
- `CROSS_COMPILE` is introduce too, if this env var is not set, native compiler is used, otherwise the cross-compiler will be used instead.