### PR TITLE
Make kernel object depend on relevant headers.

### DIFF
--- a/litepcie/software/kernel/Makefile
+++ b/litepcie/software/kernel/Makefile
@@ -13,6 +13,8 @@ all: litepcie.ko liteuart.ko
 litepcie.ko: main.c
 	make -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) modules
 
+litepcie.ko: litepcie.h config.h flags.h csr.h soc.h
+
 liteuart.ko: liteuart.c
 	make -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) modules
 


### PR DESCRIPTION
This is convenient when working on litepcie, as the kernel build system doesn't (?) support automatic dependency tracking.