### PR TITLE
Check all ioctls.

### DIFF
--- a/litepcie/software/user/liblitepcie/litepcie_flash.c
+++ b/litepcie/software/user/liblitepcie/litepcie_flash.c
@@ -32,7 +32,7 @@ static uint64_t flash_spi(int fd, int tx_len, uint8_t cmd,
     flash_spi_cs(fd, 0);
     m.tx_len = tx_len;
     m.tx_data = tx_data | ((uint64_t)cmd << 32);
-    ioctl(fd, LITEPCIE_IOCTL_FLASH, &m);
+    checked_ioctl(fd, LITEPCIE_IOCTL_FLASH, &m);
     flash_spi_cs(fd, 1);
     return m.rx_data;
 }
@@ -97,13 +97,13 @@ static void flash_write_buffer(int fd, uint32_t addr, uint8_t *buf, uint16_t siz
         /* send cmd */
         m.tx_len = 32;
         m.tx_data = ((uint64_t)FLASH_PP << 32) | ((uint64_t)addr << 8);
-        ioctl(fd, LITEPCIE_IOCTL_FLASH, &m);
+        checked_ioctl(fd, LITEPCIE_IOCTL_FLASH, &m);
 
         /* send bytes */
         for (i=0; i<size; i++) {
             m.tx_len = 8;
             m.tx_data = ((uint64_t)buf[i] << 32);
-            ioctl(fd, LITEPCIE_IOCTL_FLASH, &m);
+            checked_ioctl(fd, LITEPCIE_IOCTL_FLASH, &m);
         }
 
         /* release cs_n */
@@ -132,12 +132,12 @@ static void litepcie_flash_read_buffer(int fd, uint32_t addr, uint8_t *buf, uint
         /* send cmd */
         m.tx_len = 32;
         m.tx_data = ((uint64_t)FLASH_READ << 32) | ((uint64_t)addr << 8);
-        ioctl(fd, LITEPCIE_IOCTL_FLASH, &m);
+        checked_ioctl(fd, LITEPCIE_IOCTL_FLASH, &m);
 
         /* read bytes */
         for (i=0; i<size; i++) {
             m.tx_len = 8;
-            ioctl(fd, LITEPCIE_IOCTL_FLASH, &m);
+            checked_ioctl(fd, LITEPCIE_IOCTL_FLASH, &m);
             buf[i] = m.rx_data;
         }
 

--- a/litepcie/software/user/liblitepcie/litepcie_helpers.c
+++ b/litepcie/software/user/liblitepcie/litepcie_helpers.c
@@ -9,6 +9,10 @@
 
 #include <time.h>
 #include <sys/ioctl.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
 #include "litepcie_helpers.h"
 #include "litepcie.h"
 
@@ -23,7 +27,7 @@ uint32_t litepcie_readl(int fd, uint32_t addr) {
     struct litepcie_ioctl_reg m;
     m.is_write = 0;
     m.addr = addr;
-    ioctl(fd, LITEPCIE_IOCTL_REG, &m);
+    checked_ioctl(fd, LITEPCIE_IOCTL_REG, &m);
     return m.val;
 }
 
@@ -32,12 +36,19 @@ void litepcie_writel(int fd, uint32_t addr, uint32_t val) {
     m.is_write = 1;
     m.addr = addr;
     m.val = val;
-    ioctl(fd, LITEPCIE_IOCTL_REG, &m);
+    checked_ioctl(fd, LITEPCIE_IOCTL_REG, &m);
 }
 
 void litepcie_reload(int fd) {
     struct litepcie_ioctl_icap m;
     m.addr = 0x4;
     m.data = 0xf;
-    ioctl(fd, LITEPCIE_IOCTL_ICAP, &m);
+    checked_ioctl(fd, LITEPCIE_IOCTL_ICAP, &m);
+}
+
+void _check_ioctl(int status, const char *file, int line) {
+    if (status) {
+        fprintf(stderr, "Failed ioctl at %s:%d: %s\n", file, line, strerror(errno));
+        abort();
+    }
 }

--- a/litepcie/software/user/liblitepcie/litepcie_helpers.h
+++ b/litepcie/software/user/liblitepcie/litepcie_helpers.h
@@ -11,11 +11,15 @@
 #define LITEPCIE_LIB_HELPERS_H
 
 #include <stdint.h>
+#include <sys/ioctl.h>
 
 int64_t get_time_ms(void);
 
 uint32_t litepcie_readl(int fd, uint32_t addr);
 void litepcie_writel(int fd, uint32_t addr, uint32_t val);
 void litepcie_reload(int fd);
+
+#define checked_ioctl(...) _check_ioctl(ioctl(__VA_ARGS__), __FILE__, __LINE__)
+void _check_ioctl(int status, const char *file, int line);
 
 #endif /* LITEPCIE_LIB_HELPERS_H */


### PR DESCRIPTION
I first was using `libexplain`, which gives slightly nicer error messages, but that library doesn't seem packaged everywhere (i.e. not on Arch Linux here).