### PR TITLE
software fixes

### DIFF
--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -466,7 +466,7 @@ static ssize_t litepcie_read(struct file *file, char __user *data, size_t size, 
 	}
 
 	if (overflows)
-		dev_dbg(&s->dev->dev, "Reading too late, %d buffers lost\n", overflows);
+		dev_err(&s->dev->dev, "Reading too late, %d buffers lost\n", overflows);
 
 #ifdef DEBUG_READ
 	dev_dbg(&s->dev->dev, "read: read %ld bytes out of %ld\n", size - len, size);
@@ -520,7 +520,7 @@ static ssize_t litepcie_write(struct file *file, const char __user *data, size_t
 	}
 
 	if (underflows)
-		dev_dbg(&s->dev->dev, "Writing too late, %d buffers lost\n", underflows);
+		dev_err(&s->dev->dev, "Writing too late, %d buffers lost\n", underflows);
 
 #ifdef DEBUG_WRITE
 	dev_dbg(&s->dev->dev, "write: write %ld bytes out of %ld\n", size - len, size);

--- a/litepcie/software/user/Makefile
+++ b/litepcie/software/user/Makefile
@@ -11,10 +11,10 @@ liblitepcie/liblitepcie.a: liblitepcie/litepcie_dma.o liblitepcie/litepcie_flash
 	ar rcs $@ $+
 	ranlib $@
 
-litepcie_util: liblitepcie/liblitepcie.a litepcie_util.o helpers.o
+litepcie_util: liblitepcie/liblitepcie.a litepcie_util.o
 	$(CC) $(LDFLAGS) -o $@ $^ -Lliblitepcie -llitepcie
 
-litepcie_test: liblitepcie/liblitepcie.a litepcie_test.o helpers.o
+litepcie_test: liblitepcie/liblitepcie.a litepcie_test.o
 	$(CC) $(LDFLAGS) -o $@ $^ -Lliblitepcie -lm -llitepcie
 
 litepcie_dma_minimal_example: liblitepcie/liblitepcie.a litepcie_dma_minimal_example.o

--- a/litepcie/software/user/helpers.c
+++ b/litepcie/software/user/helpers.c
@@ -1,9 +1,0 @@
-#include <stdint.h>
-
-int64_t add_mod_int(int64_t a, int64_t b, int64_t m)
-{
-    a += b;
-    if (a >= m)
-        a -= m;
-    return a;
-}

--- a/litepcie/software/user/helpers.h
+++ b/litepcie/software/user/helpers.h
@@ -1,6 +1,0 @@
-#ifndef HELPERS_H
-#define HELPERS_H
-
-int64_t add_mod_int(int64_t a, int64_t b, int64_t m);
-
-#endif //HELPERS_H

--- a/litepcie/software/user/liblitepcie/litepcie_dma.c
+++ b/litepcie/software/user/liblitepcie/litepcie_dma.c
@@ -94,7 +94,7 @@ int litepcie_dma_init(struct litepcie_dma_ctrl *dma, const char *device_name, ui
             return -1;
         }
         if (dma->use_reader) {
-            dma->buf_rd = mmap(NULL, DMA_BUFFER_TOTAL_SIZE, PROT_READ, MAP_SHARED,
+            dma->buf_rd = mmap(NULL, DMA_BUFFER_TOTAL_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED,
                                dma->fds.fd, dma->mmap_dma_info.dma_rx_buf_offset);
             if (dma->buf_rd == MAP_FAILED) {
                 fprintf(stderr, "MMAP failed\n");

--- a/litepcie/software/user/liblitepcie/litepcie_dma.c
+++ b/litepcie/software/user/liblitepcie/litepcie_dma.c
@@ -177,7 +177,6 @@ void litepcie_dma_process(struct litepcie_dma_ctrl *dma)
             /* update dma sw_count*/
             dma->mmap_dma_update.sw_count = dma->writer_sw_count + dma->buffers_available_read;
             ioctl(dma->fds.fd, LITEPCIE_IOCTL_MMAP_DMA_WRITER_UPDATE, &dma->mmap_dma_update);
-
         } else {
             len = read(dma->fds.fd, dma->buf_rd, DMA_BUFFER_TOTAL_SIZE);
             dma->buffers_available_read = len / DMA_BUFFER_SIZE;

--- a/litepcie/software/user/litepcie_test.c
+++ b/litepcie/software/user/litepcie_test.c
@@ -16,7 +16,6 @@
 #include <math.h>
 #include <signal.h>
 #include "liblitepcie.h"
-#include "helpers.h"
 
 sig_atomic_t keep_running = 1;
 

--- a/litepcie/software/user/litepcie_util.c
+++ b/litepcie/software/user/litepcie_util.c
@@ -307,6 +307,7 @@ static void dma_test(uint8_t zero_copy)
                 if (!buf_rd)
                     break;
                 check_errors += check_pn_data((uint32_t *) buf_rd, DMA_BUFFER_SIZE / sizeof(uint32_t), &seed_rd);
+                memset(buf_rd, 0, DMA_BUFFER_SIZE);
                 if (dma.writer_hw_count > DMA_BUFFER_COUNT)
                     errors += check_errors;
             }

--- a/litepcie/software/user/litepcie_util.c
+++ b/litepcie/software/user/litepcie_util.c
@@ -285,24 +285,24 @@ static void dma_test(uint8_t zero_copy)
         litepcie_dma_process(&dma);
 
 #ifdef DMA_CHECK_DATA
-        while (1) {
-            if (n_buffers_written == DMA_BUFFER_COUNT)
-                break;
-            char *buf_wr = litepcie_dma_next_write_buffer(&dma);
-            if (!buf_wr)
-                break;
-            write_pn_data((uint32_t *) buf_wr, DMA_BUFFER_SIZE / sizeof(uint32_t), &seed_wr);
-            n_buffers_written++;
-        }
-
-        uint32_t check_errors = 0;
-        while (1) {
-            char *buf_rd = litepcie_dma_next_read_buffer(&dma);
-            if (!buf_rd)
-                break;
-            check_errors += check_pn_data((uint32_t *) buf_rd, DMA_BUFFER_SIZE / sizeof(uint32_t), &seed_rd);
-            if (dma.writer_hw_count > DMA_BUFFER_COUNT)
-                errors += check_errors;
+        if (n_buffers_written < DMA_BUFFER_COUNT) {
+            while (1) {
+                char *buf_wr = litepcie_dma_next_write_buffer(&dma);
+                if (!buf_wr)
+                    break;
+                write_pn_data((uint32_t *) buf_wr, DMA_BUFFER_SIZE / sizeof(uint32_t), &seed_wr);
+                n_buffers_written++;
+            }
+        } else {
+            uint32_t check_errors = 0;
+            while (1) {
+                char *buf_rd = litepcie_dma_next_read_buffer(&dma);
+                if (!buf_rd)
+                    break;
+                check_errors += check_pn_data((uint32_t *) buf_rd, DMA_BUFFER_SIZE / sizeof(uint32_t), &seed_rd);
+                if (dma.writer_hw_count > DMA_BUFFER_COUNT)
+                    errors += check_errors;
+            }
         }
 #endif
 

--- a/litepcie/software/user/litepcie_util.c
+++ b/litepcie/software/user/litepcie_util.c
@@ -245,9 +245,9 @@ static int check_pn_data(const uint32_t *buf, int count, uint32_t *pseed)
     seed = *pseed;
     for (i = 0; i < count; i++) {
         if (buf[i] != seed_to_data(seed)) {
-            errors++;
+            errors ++;
         }
-        seed = add_mod_int(seed, 1, DMA_BUFFER_SIZE/4);
+        seed = add_mod_int(seed, 1, DMA_BUFFER_SIZE / 4);
     }
     *pseed = seed;
     return errors;
@@ -274,9 +274,6 @@ static void dma_test(uint8_t zero_copy)
 
     if (litepcie_dma_init(&dma, litepcie_device, zero_copy))
         exit(1);
-
-#ifdef DMA_CHECK_DATA
-#endif
 
     /* test loop */
     last_time = get_time_ms();

--- a/litepcie/software/user/litepcie_util.c
+++ b/litepcie/software/user/litepcie_util.c
@@ -23,7 +23,6 @@
 
 static char litepcie_device[1024];
 static int litepcie_device_num;
-static uint8_t litepcie_device_zero_copy;
 
 sig_atomic_t keep_running = 1;
 
@@ -407,6 +406,8 @@ int main(int argc, char **argv)
 {
     const char *cmd;
     int c;
+    static uint8_t litepcie_device_zero_copy;
+
 
     litepcie_device_num = 0;
     litepcie_device_zero_copy = 0;
@@ -442,7 +443,7 @@ int main(int argc, char **argv)
     if (!strcmp(cmd, "info"))
         info();
     else if (!strcmp(cmd, "dma_test"))
-        dma_test(0);
+        dma_test(litepcie_device_zero_copy);
     else if (!strcmp(cmd, "scratch_test"))
         scratch_test();
 #ifdef CSR_UART_XOVER_RXTX_ADDR

--- a/litepcie/software/user/litepcie_util.c
+++ b/litepcie/software/user/litepcie_util.c
@@ -16,7 +16,6 @@
 #include <fcntl.h>
 #include <signal.h>
 #include "liblitepcie.h"
-#include "helpers.h"
 
 #define DMA_CHECK_DATA
 #define DMA_RANDOM_DATA
@@ -212,6 +211,14 @@ static void flash_reload(void)
 #endif
 
 /* dma */
+
+static inline int64_t add_mod_int(int64_t a, int64_t b, int64_t m)
+{
+    a += b;
+    if (a >= m)
+        a -= m;
+    return a;
+}
 
 #ifdef DMA_CHECK_DATA
 static inline uint32_t seed_to_data(uint32_t seed)


### PR DESCRIPTION
 - dev_dbg -> dev_err for DMA overflows and underflows
 - write all patterns before starting verifying them in dma_test
 - zero read buffers in dma_test for better error detection
 - minor edits