### PR TITLE
Improve liblitepcie reusability

### DIFF
--- a/litepcie/software/user/Makefile
+++ b/litepcie/software/user/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-O2 -Wall -g -I../kernel -Iliblitepcie -MMD
+CFLAGS=-O2 -Wall -g -I../kernel -Iliblitepcie -MMD -fPIC
 LDFLAGS=-g
 CC=$(CROSS_COMPILE)gcc
 AR=ar

--- a/litepcie/software/user/liblitepcie/liblitepcie.h
+++ b/litepcie/software/user/liblitepcie/liblitepcie.h
@@ -10,9 +10,17 @@
 #ifndef LITEPCIE_LIB_H
 #define LITEPCIE_LIB_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "litepcie_dma.h"
 #include "litepcie_flash.h"
 #include "litepcie_helpers.h"
 #include "litepcie.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LITEPCIE_LIB_H */


### PR DESCRIPTION
Use `-fPIC`, and add `extern C` to headers.