### PR TITLE
remove BufferizeEndpoints of LitePCIeDMAWriter

### DIFF
--- a/litepcie/frontend/dma.py
+++ b/litepcie/frontend/dma.py
@@ -402,7 +402,6 @@ class LitePCIeDMAWriter(Module, AutoCSR):
         # DMA descriptors need to be splitted in descriptors of max_request_size (negotiated at link-up)
         splitter = LitePCIeDMADescriptorSplitter(max_size=endpoint.phy.max_payload_size)
         splitter = ResetInserter()(splitter)
-        splitter = BufferizeEndpoints({"source": DIR_SOURCE})(splitter) # For timings.
         self.submodules.splitter = splitter
         if with_table:
             self.comb += self.table.source.connect(splitter.sink)


### PR DESCRIPTION
The BufferizeEndpoints used in LitePCIeDMAWriter will cause conflicts between consecutive DMA requests, and the second request will stop earlier before transferring all the data due to this conflict.  
The underlying mechanism is that, when finished the first DMA request, the ['end'](https://github.com/enjoy-digital/litepcie/blob/6e26d4c1a15b34bdda332b6fe75901616f5a55e5/litepcie/frontend/dma.py#L467) signal will be kept true when the second DMA request immediately start. And due to this [line](https://github.com/enjoy-digital/litepcie/blob/6e26d4c1a15b34bdda332b6fe75901616f5a55e5/litepcie/frontend/dma.py#L200) and this ['stop condition'](https://github.com/enjoy-digital/litepcie/blob/6e26d4c1a15b34bdda332b6fe75901616f5a55e5/litepcie/frontend/dma.py#L214), the second request will stop earlier before transferring all the data(i.e. only ['max_size'](https://github.com/enjoy-digital/litepcie/blob/6e26d4c1a15b34bdda332b6fe75901616f5a55e5/litepcie/frontend/dma.py#L201) of data is transferred).  
I found this problem when executing Scatter-Gather DMA requests, where the DMA requests start right after their predecessor. So these conflicts arise. The code I use is [here](https://github.com/tongchen126/litepcie_pcie_dma/blob/d7c7c46bd04257deca6731c82cdbe1dd90f6be73/v3/wishbone_dma.py#L199).  
The problem only arises in LitePCIeDMAWriter as LitePCIeDMAReader don't use the 'end' signal.  
This problem could also be eliminated by keeping an interval of a few clock cycles(larger than 10), between consecutive DMA requests.