### PR TITLE
phy: Add detailled status for UltraScale Plus PCIe PHY

### DIFF
--- a/litepcie/phy/usppciephy.py
+++ b/litepcie/phy/usppciephy.py
@@ -27,7 +27,35 @@ class USPPCIEPHY(Module, AutoCSR):
         self.msi        = stream.Endpoint(msi_layout())
 
         # Registers --------------------------------------------------------------------------------
-        self._link_up           = CSRStatus(description="Link Up Status. ``1``: Link is Up.")
+        self._link_status = CSRStatus(fields=[
+            CSRField("status", size=1, values=[
+                ("``0b0``", "Link Down."),
+                ("``0b1``", "Link Up."),
+            ]),
+            CSRField("phy_down", size=1, values=[
+                ("``0b0``", "PHY Link Up."),
+                ("``0b1``", "PHY Link Down."),
+            ]),
+            CSRField("phy_status", size=2, values=[
+                ("``00b``", "No receivers detected"),
+                ("``01b``", "Link training in progress"),
+                ("``10b``", "Link up, DL initialization in progress"),
+                ("``11b``", "Link up, DL initialization completed"),
+            ]),
+            CSRField("rate", size=2, values=[
+                ("``0b00``", "2.5 GT/s."),
+                ("``0b01``", "5.0 GT/s."),
+                ("``0b10``", "8.0 GT/s."),
+            ]),
+            CSRField("width", size=3, values=[
+                ("``0b000``", "1-Lane link."),
+                ("``0b001``", "2-Lane link."),
+                ("``0b010``", "4-Lane link."),
+                ("``0b011``", "8-Lane link."),
+                ("``0b100``", "16-Lane link."),
+            ]),
+            CSRField("ltssm", size=6, description="LTSSM State"),
+        ])
         self._msi_enable        = CSRStatus(description="MSI Enable Status. ``1``: MSI is enabled.")
         self._bus_master_enable = CSRStatus(description="Bus Mastering Status. ``1``: Bus Mastering enabled.")
         self._max_request_size  = CSRStatus(16, description="Negiotiated Max Request Size (in bytes).")
@@ -123,7 +151,13 @@ class USPPCIEPHY(Module, AutoCSR):
                 value = min(value*2, max_size)
             return Case(command, cases)
 
-        link_up         = Signal()
+        link_status     = Signal()
+        link_phy_down   = Signal()
+        link_phy_status = Signal(2)
+        link_rate       = Signal(2)
+        link_width      = Signal(3)
+        link_ltssm      = Signal(6)
+
         msi_enable      = Signal()
         serial_number   = Signal(64)
         bus_number      = Signal(8)
@@ -140,7 +174,12 @@ class USPPCIEPHY(Module, AutoCSR):
             self.id.eq(Cat(function_number, device_number, bus_number))
         ]
         self.specials += [
-            MultiReg(link_up, self._link_up.status),
+            MultiReg(link_status,     self._link_status.fields.status),
+            MultiReg(link_phy_down,   self._link_status.fields.phy_down),
+            MultiReg(link_phy_status, self._link_status.fields.phy_status),
+            MultiReg(link_rate,       self._link_status.fields.rate),
+            MultiReg(link_width,      self._link_status.fields.width),
+            MultiReg(link_ltssm,      self._link_status.fields.ltssm),
             MultiReg(cfg_function_status, self._bus_master_enable.status),
             MultiReg(msi_enable, self._msi_enable.status),
             MultiReg(self.max_request_size, self._max_request_size.status),
@@ -183,7 +222,7 @@ class USPPCIEPHY(Module, AutoCSR):
             # Common
             o_user_clk_out         = ClockSignal("pcie"),
             o_user_reset_out       = ResetSignal("pcie"),
-            o_user_lnk_up          = link_up,
+            o_user_lnk_up          = link_status,
             o_user_app_rdy         = Open(),
 
             # (FPGA -> Host) Requester Request
@@ -290,10 +329,10 @@ class USPPCIEPHY(Module, AutoCSR):
             o_cfg_interrupt_msi_vf_enable   = Open(8),
 
             # Error Reporting Interface ------------------------------------------------------------
-            o_cfg_phy_link_down           = Open(),
-            o_cfg_phy_link_status         = Open(2),
-            o_cfg_negotiated_width        = Open(4),
-            o_cfg_current_speed           = Open(3),
+            o_cfg_phy_link_down           = link_phy_down,
+            o_cfg_phy_link_status         = link_phy_status,
+            o_cfg_negotiated_width        = link_width,
+            o_cfg_current_speed           = link_rate,
             o_cfg_max_payload             = cfg_max_payload_size,
             o_cfg_max_read_req            = cfg_max_read_req,
             o_cfg_function_status         = cfg_function_status,
@@ -306,7 +345,7 @@ class USPPCIEPHY(Module, AutoCSR):
             o_cfg_err_nonfatal_out        = Open(),
             o_cfg_err_fatal_out           = Open(),
             o_cfg_ltr_enable              = Open(),
-            o_cfg_ltssm_state             = Open(6),
+            o_cfg_ltssm_state             = link_ltssm,
             o_cfg_rcb_status              = Open(4),
             o_cfg_dpa_substate_change     = Open(4),
             o_cfg_obff_enable             = Open(2),

--- a/litepcie/phy/xilinx_usp_gen2_x4/pcie_usp_support.v
+++ b/litepcie/phy/xilinx_usp_gen2_x4/pcie_usp_support.v
@@ -246,8 +246,8 @@ module pcie_support # (
 
   output                                     cfg_phy_link_down,
   output                            [1:0]    cfg_phy_link_status,
-  output                            [3:0]    cfg_negotiated_width,
-  output                            [2:0]    cfg_current_speed,
+  output                            [2:0]    cfg_negotiated_width,
+  output                            [1:0]    cfg_current_speed,
   output                            [2:0]    cfg_max_payload,
   output                            [2:0]    cfg_max_read_req,
   output                           [15:0]    cfg_function_status,

--- a/litepcie/phy/xilinx_usp_gen3_x16/pcie_usp_support.v
+++ b/litepcie/phy/xilinx_usp_gen3_x16/pcie_usp_support.v
@@ -260,8 +260,8 @@ module pcie_support # (
 
   output                                     cfg_phy_link_down,
   output                            [1:0]    cfg_phy_link_status,
-  output                            [3:0]    cfg_negotiated_width,
-  output                            [2:0]    cfg_current_speed,
+  output                            [2:0]    cfg_negotiated_width,
+  output                            [1:0]    cfg_current_speed,
   output                            [2:0]    cfg_max_payload,
   output                            [2:0]    cfg_max_read_req,
   output                           [15:0]    cfg_function_status,

--- a/litepcie/phy/xilinx_usp_gen3_x4/pcie_usp_support.v
+++ b/litepcie/phy/xilinx_usp_gen3_x4/pcie_usp_support.v
@@ -262,8 +262,8 @@ module pcie_support # (
 
   output                                     cfg_phy_link_down,
   output                            [1:0]    cfg_phy_link_status,
-  output                            [3:0]    cfg_negotiated_width,
-  output                            [2:0]    cfg_current_speed,
+  output                            [2:0]    cfg_negotiated_width,
+  output                            [1:0]    cfg_current_speed,
   output                            [2:0]    cfg_max_payload,
   output                            [2:0]    cfg_max_read_req,
   output                           [15:0]    cfg_function_status,

--- a/litepcie/phy/xilinx_usp_gen3_x8/pcie_usp_support.v
+++ b/litepcie/phy/xilinx_usp_gen3_x8/pcie_usp_support.v
@@ -262,8 +262,8 @@ module pcie_support # (
 
   output                                     cfg_phy_link_down,
   output                            [1:0]    cfg_phy_link_status,
-  output                            [3:0]    cfg_negotiated_width,
-  output                            [2:0]    cfg_current_speed,
+  output                            [2:0]    cfg_negotiated_width,
+  output                            [1:0]    cfg_current_speed,
   output                            [2:0]    cfg_max_payload,
   output                            [2:0]    cfg_max_read_req,
   output                           [15:0]    cfg_function_status,

--- a/litepcie/phy/xilinx_usp_hbm_gen2_x4/pcie_usp_support.v
+++ b/litepcie/phy/xilinx_usp_hbm_gen2_x4/pcie_usp_support.v
@@ -246,8 +246,8 @@ module pcie_support # (
 
   output                                     cfg_phy_link_down,
   output                            [1:0]    cfg_phy_link_status,
-  output                            [3:0]    cfg_negotiated_width,
-  output                            [2:0]    cfg_current_speed,
+  output                            [2:0]    cfg_negotiated_width,
+  output                            [1:0]    cfg_current_speed,
   output                            [2:0]    cfg_max_payload,
   output                            [2:0]    cfg_max_read_req,
   output                           [15:0]    cfg_function_status,

--- a/litepcie/phy/xilinx_usp_hbm_gen3_x4/pcie_usp_support.v
+++ b/litepcie/phy/xilinx_usp_hbm_gen3_x4/pcie_usp_support.v
@@ -262,8 +262,8 @@ module pcie_support # (
 
   output                                     cfg_phy_link_down,
   output                            [1:0]    cfg_phy_link_status,
-  output                            [3:0]    cfg_negotiated_width,
-  output                            [2:0]    cfg_current_speed,
+  output                            [2:0]    cfg_negotiated_width,
+  output                            [1:0]    cfg_current_speed,
   output                            [2:0]    cfg_max_payload,
   output                            [2:0]    cfg_max_read_req,
   output                           [15:0]    cfg_function_status,


### PR DESCRIPTION
Note we also fix the cfg_negotiated_width and cfg_current_speed
signal with in the support wrapper since those have different
encoding than in the UltraScale blocks.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>