### PR TITLE
litepcie/software/kernel/main.c: fix build with kernel >= 5.18 (pci_set_dma_mask -> dma_set_mask)

### DIFF
--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -32,6 +32,7 @@
 #include <linux/poll.h>
 #include <linux/cdev.h>
 #include <linux/platform_device.h>
+#include <linux/version.h>
 
 #include "litepcie.h"
 #include "csr.h"
@@ -1035,7 +1036,11 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 	dev_info(&dev->dev, "Version %s\n", fpga_identifier);
 
 	pci_set_master(dev);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0)
 	ret = pci_set_dma_mask(dev, DMA_BIT_MASK(32));
+#else
+	ret = dma_set_mask(&dev->dev, DMA_BIT_MASK(32));
+#endif
 	if (ret) {
 		dev_err(&dev->dev, "Failed to set DMA mask\n");
 		goto fail1;


### PR DESCRIPTION
Since kernel 5.18 `pci_set_dma_mask` is more available and must be recplaced by `dma_set_mask`.