### PR TITLE
init Nvidia RDMA/ PCIe P2P Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Frontend:
   - MMAP (AXI/Wishbone Slave/Master).
 
 Software:
-  - Linux Driver (MMAP and DMA).
+  - Linux Driver (MMAP, DMA, Nvidia RDMA).
 
 [> FPGA Proven
 ---------------
@@ -89,6 +89,14 @@ Tests can also be run individually:
 ```sh
 $ python3 -m unittest test.test_name
 ```
+
+[> Nvidia RDMA Support
+----------------------
+The Linux driver supports Nvidia's RDMA (Remote Direct Memory Access) API,
+allowing for direct data transfers between the FPGA and an Nvidia GPU.
+No gateware changes are required to enable this feature.
+It is recommended that the [Nvidia open-source GPU kernel module](https://github.com/NVIDIA/open-gpu-kernel-modules)
+ be used.
 
 [> License
 ----------

--- a/litepcie/software/kernel/Makefile
+++ b/litepcie/software/kernel/Makefile
@@ -3,21 +3,40 @@ KERNEL_VERSION:=$(shell uname -r)
 KERNEL_PATH?=/lib/modules/$(KERNEL_VERSION)/build
 ARCH?=$(shell uname -m)
 
+# Export `REPO_DIR` so that when the kernel's byzantine makefile system re-includes us,
+# it's already set properly and doesn't get re-set with the wrong path.
+REPO_DIR ?= $(shell dirname $(shell dirname $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))))
+export REPO_DIR
+
+NVIDIA_PATH ?= ~/open-gpu-kernel-modules/
+
+NV_DMA ?= false
+
 obj-m = litepcie.o liteuart.o
 litepcie-objs = main.o
 #liteuart-objs = liteuart.o
 
+ifeq ($(NV_DMA),true)
+ccflags-y += -I$(NVIDIA_PATH)/kernel-open/nvidia -DNV_DMA=$(NV_DMA)
+
+# don't warn about missing NVIDIA symbols; they'll be available
+# TODO: create our own Module.symvers,
+#       https://github.com/NVIDIA/gds-nvidia-fs/blob/af3f7de96b4e500abf30e3034e5827749953bd68/src/Makefile#L108-L112
+KBUILD_MODPOST_WARN=1
+endif
 
 all: litepcie.ko liteuart.ko
 
-litepcie.ko: main.c
-	make -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) modules
+litepcie.ko liteuart.ko &: main.c liteuart.c litepcie.h config.h flags.h #csr.h soc.h
+	$(MAKE) -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) modules
 
-litepcie.ko: litepcie.h config.h flags.h csr.h soc.h
+modules: litepcie.ko liteuart.ko
 
-liteuart.ko: liteuart.c
-	make -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) modules
+modules_install: modules
+	$(MAKE) -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) modules_install
 
 clean:
-	make -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) clean
+	$(MAKE) -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) clean
 	rm -f *~
+
+print-%  : ; @echo $* = $($*)

--- a/litepcie/software/kernel/litepcie.h
+++ b/litepcie/software/kernel/litepcie.h
@@ -33,6 +33,12 @@ struct litepcie_ioctl_icap {
 	uint32_t data;
 };
 
+struct litepcie_ioctl_dma_init {
+	uint8_t use_gpu;
+	uint64_t gpu_addr;
+	uint64_t gpu_size;
+};
+
 struct litepcie_ioctl_dma {
 	uint8_t loopback_enable;
 };
@@ -78,6 +84,7 @@ struct litepcie_ioctl_mmap_dma_update {
 #define LITEPCIE_IOCTL_FLASH             _IOWR(LITEPCIE_IOCTL,  1, struct litepcie_ioctl_flash)
 #define LITEPCIE_IOCTL_ICAP              _IOWR(LITEPCIE_IOCTL,  2, struct litepcie_ioctl_icap)
 
+#define LITEPCIE_IOCTL_DMA_INIT                  _IOW(LITEPCIE_IOCTL,  19, struct litepcie_ioctl_dma_init)
 #define LITEPCIE_IOCTL_DMA                       _IOW(LITEPCIE_IOCTL,  20, struct litepcie_ioctl_dma)
 #define LITEPCIE_IOCTL_DMA_WRITER                _IOWR(LITEPCIE_IOCTL, 21, struct litepcie_ioctl_dma_writer)
 #define LITEPCIE_IOCTL_DMA_READER                _IOWR(LITEPCIE_IOCTL, 22, struct litepcie_ioctl_dma_reader)

--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -38,6 +38,10 @@
 #include "config.h"
 #include "flags.h"
 
+#ifdef NV_DMA
+#include "nv-p2p.h"
+#endif
+
 //#define DEBUG_CSR
 //#define DEBUG_MSI
 //#define DEBUG_POLL
@@ -47,14 +51,24 @@
 #define LITEPCIE_NAME "litepcie"
 #define LITEPCIE_MINOR_COUNT 32
 
+enum DMASource { None, CPU, GPU };
+
 struct litepcie_dma_chan {
 	uint32_t base;
 	uint32_t writer_interrupt;
 	uint32_t reader_interrupt;
+
+	// addresses that can be passed to the hardware
 	dma_addr_t reader_handle[DMA_BUFFER_COUNT];
 	dma_addr_t writer_handle[DMA_BUFFER_COUNT];
+
+	// addresses pointing to the allocated DMA memory.
+	// - for CPU memory, these are virtual addresses
+	// - for GPU memory, these are physical addresses
+	//   (as the kernel does not understandn virtual GPU addresses)
 	uint32_t *reader_addr[DMA_BUFFER_COUNT];
 	uint32_t *writer_addr[DMA_BUFFER_COUNT];
+
 	int64_t reader_hw_count;
 	int64_t reader_hw_count_last;
 	int64_t reader_sw_count;
@@ -91,6 +105,13 @@ struct litepcie_device {
 	int minor_base;
 	int irqs;
 	int channels;
+
+	enum DMASource dma_source;
+	#ifdef NV_DMA
+	uint64_t gpu_virt_start;	// start page address of the virtual memory
+	nvidia_p2p_page_table_t *gpu_page_table;
+	nvidia_p2p_dma_mapping_t *gpu_dma_mapping;
+	#endif
 };
 
 struct litepcie_chan_priv {
@@ -141,14 +162,15 @@ static void litepcie_disable_interrupt(struct litepcie_device *s, int irq_num)
 	litepcie_writel(s, CSR_PCIE_MSI_ENABLE_ADDR, v);
 }
 
-static int litepcie_dma_init(struct litepcie_device *s)
+static int litepcie_dma_init_cpu(struct litepcie_device *s)
 {
-
 	int i, j;
 	struct litepcie_dma_chan *dmachan;
 
 	if (!s)
 		return -ENODEV;
+	if (s->dma_source != None)
+		return -EINVAL;
 
 	/* for each dma channel */
 	for (i = 0; i < s->channels; i++) {
@@ -156,13 +178,13 @@ static int litepcie_dma_init(struct litepcie_device *s)
 		/* for each dma buffer */
 		for (j = 0; j < DMA_BUFFER_COUNT; j++) {
 			/* allocate rd */
-			dmachan->reader_addr[j] = dmam_alloc_coherent(
+			dmachan->reader_addr[j] = dma_alloc_coherent(
 				&s->dev->dev,
 				DMA_BUFFER_SIZE,
 				&dmachan->reader_handle[j],
 				GFP_KERNEL);
 			/* allocate wr */
-			dmachan->writer_addr[j] = dmam_alloc_coherent(
+			dmachan->writer_addr[j] = dma_alloc_coherent(
 				&s->dev->dev,
 				DMA_BUFFER_SIZE,
 				&dmachan->writer_handle[j],
@@ -176,13 +198,210 @@ static int litepcie_dma_init(struct litepcie_device *s)
 		}
 	}
 
+	s->dma_source = CPU;
 	return 0;
 }
 
-static void litepcie_dma_writer_start(struct litepcie_device *s, int chan_num)
+static int litepcie_dma_deinit_cpu(struct litepcie_device *s)
+{
+	int i, j;
+	struct litepcie_dma_chan *dmachan;
+
+	/* for each dma channel */
+	for (i = 0; i < s->channels; i++) {
+		dmachan = &s->chan[i].dma;
+		/* for each dma buffer */
+		for (j = 0; j < DMA_BUFFER_COUNT; j++) {
+			/* allocate rd */
+			dma_free_coherent(
+				&s->dev->dev,
+				DMA_BUFFER_SIZE,
+				dmachan->reader_addr[j],
+				dmachan->reader_handle[j]
+			);
+			/* allocate wr */
+			dma_free_coherent(
+				&s->dev->dev,
+				DMA_BUFFER_SIZE,
+				dmachan->writer_addr[j],
+				dmachan->writer_handle[j]
+			);
+		}
+	}
+
+	s->dma_source = None;
+	return 0;
+}
+
+#ifdef NV_DMA
+
+// NVIDIA GPUs use 64K pages
+#define GPU_PAGE_SHIFT		16
+#define GPU_PAGE_SIZE		(1UL << GPU_PAGE_SHIFT)
+#define GPU_PAGE_OFFSET		(GPU_PAGE_SIZE - 1)
+#define GPU_PAGE_MASK		(~GPU_PAGE_OFFSET)
+
+// callback for when the GPU mapping needs to be revoked earlier,
+// e.g. because the userspace process exited, freed the buffer, or
+// when the NVIDIA driver handle is released before the LitePCIe one.
+void litepcie_dma_free_gpu(void *data) {
+	int error;
+	struct litepcie_device *s = (struct litepcie_device *)data;
+	if (s && s->dma_source == GPU) {
+		// TODO: wait for outstanding DMAs to complete?
+
+		error = nvidia_p2p_free_dma_mapping(s->gpu_dma_mapping);
+		if (error != 0)
+			dev_err(&s->dev->dev, "Error in nvidia_p2p_free_dma_mapping()\n");
+
+		error = nvidia_p2p_free_page_table(s->gpu_page_table);
+		if (error != 0)
+			dev_err(&s->dev->dev, "Error in nvidia_p2p_free_page_table()\n");
+
+		// this ensures later release of the LitePCIe driver handle
+		// won't try to release these GPU resources again.
+		s->dma_source = None;
+	}
+}
+
+static int litepcie_dma_deinit_gpu(struct litepcie_device *s)
+{
+	int error;
+
+	error = nvidia_p2p_dma_unmap_pages(s->dev, s->gpu_page_table, s->gpu_dma_mapping);
+	if (error != 0) {
+		dev_err(&s->dev->dev, "Error in nvidia_p2p_dma_unmap_pages()\n");
+		return -EINVAL;
+	}
+
+	error = nvidia_p2p_put_pages(0, 0, s->gpu_virt_start, s->gpu_page_table);
+	if (error != 0) {
+		dev_err(&s->dev->dev, "Error in nvidia_p2p_put_pages()\n");
+		return -EINVAL;
+	}
+
+	s->dma_source = None;
+	return 0;
+}
+
+static int litepcie_dma_init_gpu(struct litepcie_device *s, uint64_t addr, uint64_t size)
+{
+	int error;
+	int i, j;
+	struct litepcie_dma_chan *dmachan;
+	size_t pin_size;
+	int page, offset;
+	struct nvidia_p2p_page * nvp;
+
+	if (!s)
+		return -ENODEV;
+	if (s->dma_source != None)
+		return -EINVAL;
+
+	// alignment as required by the NVIDIA driver
+	s->gpu_virt_start = (addr & GPU_PAGE_MASK);
+	pin_size = addr + size - s->gpu_virt_start;
+	if (!pin_size) {
+		dev_err(&s->dev->dev, "Error invalid memory size!\n");
+		error = -EINVAL;
+		goto do_exit;
+	}
+
+	// make the virtual memory accessible to other devices
+	error = nvidia_p2p_get_pages(
+		0, 0, s->gpu_virt_start, pin_size, &s->gpu_page_table,
+		litepcie_dma_free_gpu, s);
+	if (error != 0) {
+		dev_err(&s->dev->dev, "Error in nvidia_p2p_get_pages()\n");
+		error = -EINVAL;
+		goto do_exit;
+	}
+
+	BUG_ON(!s->gpu_page_table);
+	if (! NVIDIA_P2P_PAGE_TABLE_VERSION_COMPATIBLE(s->gpu_page_table)) {
+		dev_err(&s->dev->dev, "Incompatible page table version 0x%08x\n",
+		        s->gpu_page_table->version);
+		error = -EINVAL;
+		goto do_exit;
+	}
+
+	// make the physical memory accessible to other devices
+	error = nvidia_p2p_dma_map_pages(s->dev, s->gpu_page_table, &s->gpu_dma_mapping);
+	if (error != 0) {
+		dev_err(&s->dev->dev, "Error in nvidia_p2p_dma_map_pages()\n");
+		error = -EINVAL;
+		goto do_unlock_pages;
+	}
+
+	if (!NVIDIA_P2P_DMA_MAPPING_VERSION_COMPATIBLE(s->gpu_dma_mapping)) {
+		dev_err(&s->dev->dev, "Incompatible DMA mapping version 0x%08x\n",
+		        s->gpu_dma_mapping->version);
+		error = -EINVAL;
+		goto do_unlock_pages;
+	}
+	BUG_ON(s->gpu_page_table->entries != s->gpu_dma_mapping->entries);
+
+	/* for each dma channel */
+	page = 0;
+	offset = 0;
+	for (i = 0; i < s->channels; i++) {
+		dmachan = &s->chan[i].dma;
+		/* for each dma buffer */
+		for (j = 0; j < DMA_BUFFER_COUNT; j++) {
+			/* allocate rd */
+			if (offset + DMA_BUFFER_SIZE > GPU_PAGE_SIZE) {
+				page += 1;
+				offset = 0;
+			}
+			if (page >= s->gpu_page_table->entries) {
+				error = -ENOMEM;
+				goto do_unmap_pages;
+			}
+			nvp = s->gpu_page_table->pages[page];
+			BUG_ON(!nvp);
+			dmachan->reader_addr[j] = (uint32_t*)(nvp->physical_address + offset);
+			dmachan->reader_handle[j] = ((dma_addr_t)s->gpu_dma_mapping->dma_addresses[page]) + offset;
+			offset += DMA_BUFFER_SIZE;
+
+			/* allocate wr */
+			if (offset + DMA_BUFFER_SIZE > GPU_PAGE_SIZE) {
+				page += 1;
+				offset = 0;
+			}
+			if (page >= s->gpu_page_table->entries) {
+				error = -ENOMEM;
+				goto do_unmap_pages;
+			}
+			nvp = s->gpu_page_table->pages[page];
+			BUG_ON(!nvp);
+			dmachan->writer_addr[j] = (uint32_t*)(nvp->physical_address + offset);
+			dmachan->writer_handle[j] = ((dma_addr_t)s->gpu_dma_mapping->dma_addresses[page]) + offset;
+			offset += DMA_BUFFER_SIZE;
+		}
+	}
+
+	s->dma_source = GPU;
+	return 0;
+
+do_unmap_pages:
+	nvidia_p2p_dma_unmap_pages(s->dev, s->gpu_page_table, s->gpu_dma_mapping);
+do_unlock_pages:
+	nvidia_p2p_put_pages(0, 0, s->gpu_virt_start, s->gpu_page_table);
+do_exit:
+	return error;
+}
+
+#endif
+
+static int litepcie_dma_writer_start(struct litepcie_device *s, int chan_num)
 {
 	struct litepcie_dma_chan *dmachan;
 	int i;
+
+	if (!s)
+		return -ENODEV;
+	if (s->dma_source == None)
+		return -EINVAL;
 
 	dmachan = &s->chan[chan_num].dma;
 
@@ -212,11 +431,18 @@ static void litepcie_dma_writer_start(struct litepcie_device *s, int chan_num)
 
 	/* Start DMA Writer. */
 	litepcie_writel(s, dmachan->base + PCIE_DMA_WRITER_ENABLE_OFFSET, 1);
+
+	return 0;
 }
 
-static void litepcie_dma_writer_stop(struct litepcie_device *s, int chan_num)
+static int litepcie_dma_writer_stop(struct litepcie_device *s, int chan_num)
 {
 	struct litepcie_dma_chan *dmachan;
+
+	if (!s)
+		return -ENODEV;
+	if (s->dma_source == None)
+		return -EINVAL;
 
 	dmachan = &s->chan[chan_num].dma;
 
@@ -231,12 +457,19 @@ static void litepcie_dma_writer_stop(struct litepcie_device *s, int chan_num)
 	dmachan->writer_hw_count = 0;
 	dmachan->writer_hw_count_last = 0;
 	dmachan->writer_sw_count = 0;
+
+	return 0;
 }
 
-static void litepcie_dma_reader_start(struct litepcie_device *s, int chan_num)
+static int litepcie_dma_reader_start(struct litepcie_device *s, int chan_num)
 {
 	struct litepcie_dma_chan *dmachan;
 	int i;
+
+	if (!s)
+		return -ENODEV;
+	if (s->dma_source == None)
+		return -EINVAL;
 
 	dmachan = &s->chan[chan_num].dma;
 
@@ -266,11 +499,18 @@ static void litepcie_dma_reader_start(struct litepcie_device *s, int chan_num)
 
 	/* start dma reader */
 	litepcie_writel(s, dmachan->base + PCIE_DMA_READER_ENABLE_OFFSET, 1);
+
+	return 0;
 }
 
-static void litepcie_dma_reader_stop(struct litepcie_device *s, int chan_num)
+static int litepcie_dma_reader_stop(struct litepcie_device *s, int chan_num)
 {
 	struct litepcie_dma_chan *dmachan;
+
+	if (!s)
+		return -ENODEV;
+	if (s->dma_source == None)
+		return -EINVAL;
 
 	dmachan = &s->chan[chan_num].dma;
 
@@ -285,6 +525,8 @@ static void litepcie_dma_reader_stop(struct litepcie_device *s, int chan_num)
 	dmachan->reader_hw_count = 0;
 	dmachan->reader_hw_count_last = 0;
 	dmachan->reader_sw_count = 0;
+
+	return 0;
 }
 
 void litepcie_stop_dma(struct litepcie_device *s)
@@ -421,6 +663,14 @@ static int litepcie_release(struct inode *inode, struct file *file)
 		chan->dma.writer_enable = 0;
 	}
 
+	/* Free DMA sources */
+	if (chan->litepcie_dev->dma_source == CPU)
+		litepcie_dma_deinit_cpu(chan->litepcie_dev);
+	#ifdef NV_DMA
+	else if (chan->litepcie_dev->dma_source == GPU)
+		litepcie_dma_deinit_gpu(chan->litepcie_dev);
+	#endif
+
 	kfree(chan_priv);
 
 	return 0;
@@ -435,6 +685,13 @@ static ssize_t litepcie_read(struct file *file, char __user *data, size_t size, 
 	struct litepcie_chan_priv *chan_priv = file->private_data;
 	struct litepcie_chan *chan = chan_priv->chan;
 	struct litepcie_device *s = chan->litepcie_dev;
+
+	if (!s)
+		return -ENODEV;
+
+	// this syscall is not supported for GPU-backed DMA channels
+	if (s->dma_source != CPU)
+		return -EINVAL;
 
 	if (file->f_flags & O_NONBLOCK) {
 		if (chan->dma.writer_hw_count == chan->dma.writer_sw_count)
@@ -491,6 +748,13 @@ static ssize_t litepcie_write(struct file *file, const char __user *data, size_t
 	struct litepcie_chan *chan = chan_priv->chan;
 	struct litepcie_device *s = chan->litepcie_dev;
 
+	if (!s)
+		return -ENODEV;
+
+	// this syscall is not supported for GPU-backed DMA channels
+	if (s->dma_source != CPU)
+		return -EINVAL;
+
 	if (file->f_flags & O_NONBLOCK) {
 		if (chan->dma.reader_hw_count == chan->dma.reader_sw_count)
 			ret = -EAGAIN;
@@ -543,6 +807,11 @@ static int litepcie_mmap(struct file *file, struct vm_area_struct *vma)
 	unsigned long pfn;
 	int is_tx, i;
 
+	if (!s)
+		return -ENODEV;
+	if (s->dma_source == None)
+		return -EINVAL;
+
 	if (vma->vm_end - vma->vm_start != DMA_BUFFER_TOTAL_SIZE)
 		return -EINVAL;
 
@@ -554,10 +823,21 @@ static int litepcie_mmap(struct file *file, struct vm_area_struct *vma)
 		return -EINVAL;
 
 	for (i = 0; i < DMA_BUFFER_COUNT; i++) {
-		if (is_tx)
-			pfn = __pa(chan->dma.reader_addr[i]) >> PAGE_SHIFT;
-		else
-			pfn = __pa(chan->dma.writer_addr[i]) >> PAGE_SHIFT;
+		if (s->dma_source == GPU) {
+			// with GPU-backed memory buffers, addresses are physical already
+			if (is_tx)
+				pfn = ((unsigned long)chan->dma.reader_addr[i]) >> PAGE_SHIFT;
+			else
+				pfn = ((unsigned long)chan->dma.writer_addr[i]) >> PAGE_SHIFT;
+
+		} else {
+			if (is_tx)
+				pfn = __pa(chan->dma.reader_addr[i]) >> PAGE_SHIFT;
+			else
+				pfn = __pa(chan->dma.writer_addr[i]) >> PAGE_SHIFT;
+		}
+		// XXX: why is >> PAGE_SHIFT required?
+
 		/*
 		 * Note: the memory is cached, so the user must explicitly
 		 * flush the CPU caches on architectures which require it.
@@ -578,9 +858,12 @@ static unsigned int litepcie_poll(struct file *file, poll_table *wait)
 
 	struct litepcie_chan_priv *chan_priv = file->private_data;
 	struct litepcie_chan *chan = chan_priv->chan;
-#ifdef DEBUG_POLL
 	struct litepcie_device *s = chan->litepcie_dev;
-#endif
+
+	if (!s)
+		return -ENODEV;
+	if (s->dma_source == None)
+		return -EINVAL;
 
 	poll_wait(file, &chan->wait_rd, wait);
 	poll_wait(file, &chan->wait_wr, wait);
@@ -693,6 +976,27 @@ static long litepcie_ioctl(struct file *file, unsigned int cmd,
 	}
 	break;
 #endif
+	case LITEPCIE_IOCTL_DMA_INIT:
+	{
+		struct litepcie_ioctl_dma_init m;
+
+		if (copy_from_user(&m, (void *)arg, sizeof(m))) {
+			ret = -EFAULT;
+			break;
+		}
+
+		/* allocate all dma buffers */
+		#ifdef NV_DMA
+		if (m.use_gpu)
+			ret = litepcie_dma_init_gpu(chan->litepcie_dev, m.gpu_addr, m.gpu_size);
+		else
+			ret = litepcie_dma_init_cpu(chan->litepcie_dev);
+		#else
+		ret = litepcie_dma_init_cpu(chan->litepcie_dev);
+		#endif
+
+		break;
+	}
 	case LITEPCIE_IOCTL_DMA:
 	{
 		struct litepcie_ioctl_dma m;
@@ -751,11 +1055,13 @@ static long litepcie_ioctl(struct file *file, unsigned int cmd,
 		if (m.enable != chan->dma.reader_enable) {
 			/* enable / disable DMA */
 			if (m.enable) {
-				litepcie_dma_reader_start(chan->litepcie_dev, chan->index);
+				ret = litepcie_dma_reader_start(chan->litepcie_dev, chan->index);
+				if (ret != 0)
+					break;
 				litepcie_enable_interrupt(chan->litepcie_dev, chan->dma.reader_interrupt);
 			} else {
 				litepcie_disable_interrupt(chan->litepcie_dev, chan->dma.reader_interrupt);
-				litepcie_dma_reader_stop(chan->litepcie_dev, chan->index);
+				ret = litepcie_dma_reader_stop(chan->litepcie_dev, chan->index);
 			}
 		}
 
@@ -1148,13 +1454,6 @@ static int litepcie_pci_probe(struct pci_dev *dev, const struct pci_device_id *i
 		}
 	}
 
-	/* allocate all dma buffers */
-	ret = litepcie_dma_init(litepcie_dev);
-	if (ret) {
-		dev_err(&dev->dev, "Failed to allocate DMA\n");
-		goto fail3;
-	}
-
 #ifdef CSR_UART_XOVER_RXTX_ADDR
 	tty_res = devm_kzalloc(&dev->dev, sizeof(struct resource), GFP_KERNEL);
 	if (!tty_res)
@@ -1190,7 +1489,8 @@ static void litepcie_pci_remove(struct pci_dev *dev)
 	dev_info(&dev->dev, "\e[1m[Removing device]\e[0m\n");
 
 	/* Stop the DMAs */
-	litepcie_stop_dma(litepcie_dev);
+	if (litepcie_dev->dma_source != None)
+		litepcie_stop_dma(litepcie_dev);
 
 	/* Disable all interrupts */
 	litepcie_writel(litepcie_dev, CSR_PCIE_MSI_ENABLE_ADDR, 0);

--- a/litepcie/software/user/Makefile
+++ b/litepcie/software/user/Makefile
@@ -5,6 +5,11 @@ AR=ar
 
 PROGS=litepcie_util litepcie_test
 
+ifeq ($(NV_DMA),true)
+	LDFLAGS += -L$(CUDA_PREFIX)/lib -L$(CUDA_PREFIX)/lib64 -L$(CUDA_PREFIX)/lib64/stubs  -lcuda
+	CFLAGS += -I$(CUDA_PREFIX)/include -DNV_DMA
+endif
+
 all: $(PROGS)
 
 liblitepcie/liblitepcie.a: liblitepcie/litepcie_dma.o liblitepcie/litepcie_flash.o liblitepcie/litepcie_helpers.o

--- a/litepcie/software/user/liblitepcie/litepcie_dma.h
+++ b/litepcie/software/user/liblitepcie/litepcie_dma.h
@@ -12,10 +12,13 @@
 
 #include <stdint.h>
 #include <poll.h>
+#ifdef NV_DMA
+#include <cuda.h>
+#endif
 #include "litepcie.h"
 
 struct litepcie_dma_ctrl {
-    uint8_t use_reader, use_writer, loopback, zero_copy;
+    uint8_t use_reader, use_writer, loopback, zero_copy, gpu;
     struct pollfd fds;
     char *buf_rd, *buf_wr;
     int64_t reader_hw_count, reader_sw_count;
@@ -24,6 +27,9 @@ struct litepcie_dma_ctrl {
     unsigned usr_read_buf_offset, usr_write_buf_offset;
     struct litepcie_ioctl_mmap_dma_info mmap_dma_info;
     struct litepcie_ioctl_mmap_dma_update mmap_dma_update;
+    #ifdef NV_DMA
+    CUdeviceptr gpu_buf;
+    #endif
 };
 
 void litepcie_dma_set_loopback(int fd, uint8_t loopback_enable);
@@ -33,7 +39,7 @@ void litepcie_dma_writer(int fd, uint8_t enable, int64_t *hw_count, int64_t *sw_
 uint8_t litepcie_request_dma(int fd, uint8_t reader, uint8_t writer);
 void litepcie_release_dma(int fd, uint8_t reader, uint8_t writer);
 
-int litepcie_dma_init(struct litepcie_dma_ctrl *dma, const char *device_name, uint8_t zero_copy);
+int litepcie_dma_init(struct litepcie_dma_ctrl *dma, const char *device_name, uint8_t zero_copy, uint8_t gpu);
 void litepcie_dma_cleanup(struct litepcie_dma_ctrl *dma);
 void litepcie_dma_process(struct litepcie_dma_ctrl *dma);
 char *litepcie_dma_next_read_buffer(struct litepcie_dma_ctrl *dma);

--- a/litepcie/software/user/liblitepcie/litepcie_helpers.c
+++ b/litepcie/software/user/liblitepcie/litepcie_helpers.c
@@ -24,7 +24,7 @@ int64_t get_time_ms(void)
 }
 
 uint32_t litepcie_readl(int fd, uint32_t addr) {
-    struct litepcie_ioctl_reg m;
+    struct litepcie_ioctl_reg m = {0};
     m.is_write = 0;
     m.addr = addr;
     checked_ioctl(fd, LITEPCIE_IOCTL_REG, &m);
@@ -32,7 +32,7 @@ uint32_t litepcie_readl(int fd, uint32_t addr) {
 }
 
 void litepcie_writel(int fd, uint32_t addr, uint32_t val) {
-    struct litepcie_ioctl_reg m;
+    struct litepcie_ioctl_reg m = {0};
     m.is_write = 1;
     m.addr = addr;
     m.val = val;
@@ -52,3 +52,20 @@ void _check_ioctl(int status, const char *file, int line) {
         abort();
     }
 }
+
+#ifdef NV_DMA
+void _check_cuda_call(CUresult status, const char *file, int line) {
+    if (status != CUDA_SUCCESS) {
+        const char *perrstr = 0;
+        CUresult ok = cuGetErrorString(status, &perrstr);
+        if (ok == CUDA_SUCCESS) {
+            if (perrstr) {
+                fprintf(stderr, "CUDA error at %s:%d: %s\n", file, line, perrstr);
+            } else {
+                fprintf(stderr, "CUDA error at %s:%d: unknown error\n", file, line);
+            }
+        }
+        abort();
+    }
+}
+#endif

--- a/litepcie/software/user/liblitepcie/litepcie_helpers.h
+++ b/litepcie/software/user/liblitepcie/litepcie_helpers.h
@@ -12,6 +12,9 @@
 
 #include <stdint.h>
 #include <sys/ioctl.h>
+#ifdef NV_DMA
+#include <cuda.h>
+#endif
 
 int64_t get_time_ms(void);
 
@@ -21,5 +24,10 @@ void litepcie_reload(int fd);
 
 #define checked_ioctl(...) _check_ioctl(ioctl(__VA_ARGS__), __FILE__, __LINE__)
 void _check_ioctl(int status, const char *file, int line);
+
+#ifdef NV_DMA
+#define checked_cuda_call(status) { _check_cuda_call((status), __FILE__, __LINE__); }
+void _check_cuda_call(CUresult status, const char *file, int line);
+#endif
 
 #endif /* LITEPCIE_LIB_HELPERS_H */

--- a/litepcie/software/user/litepcie_test.c
+++ b/litepcie/software/user/litepcie_test.c
@@ -50,7 +50,7 @@ static void litepcie_record(const char *device_name, const char *filename, uint3
     }
 
     /* Initialize DMA. */
-    if (litepcie_dma_init(&dma, device_name, zero_copy))
+    if (litepcie_dma_init(&dma, device_name, zero_copy, 0))
         exit(1);
 
     /* Test Loop. */
@@ -129,7 +129,7 @@ static void litepcie_play(const char *device_name, const char *filename, uint32_
     }
 
     /* Initialize DMA. */
-    if (litepcie_dma_init(&dma, device_name, zero_copy))
+    if (litepcie_dma_init(&dma, device_name, zero_copy, 0))
         exit(1);
 
     /* Test Loop. */

--- a/litepcie/software/user/litepcie_util.c
+++ b/litepcie/software/user/litepcie_util.c
@@ -29,6 +29,8 @@
 static char litepcie_device[1024];
 static int litepcie_device_num;
 
+static int cuda_device_num;
+
 sig_atomic_t keep_running = 1;
 
 void intHandler(int dummy) {
@@ -74,6 +76,32 @@ static void info(void)
            (double)litepcie_readl(fd, CSR_XADC_VCCBRAM_ADDR) / 4096 * 3);
 #endif
     close(fd);
+#ifdef NV_DMA
+    if (cuda_device_num >= 0) {
+        checked_cuda_call(cuInit(0));
+
+        CUdevice device;
+        checked_cuda_call(cuDeviceGet(&device, cuda_device_num));
+
+        char name[256];
+        checked_cuda_call(cuDeviceGetName(name, 256, device));
+        fprintf(stderr, "GPU identification: %s\n", name);
+
+        // get compute capabilities and the devicename
+        int major = 0, minor = 0;
+        checked_cuda_call(
+            cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device));
+        checked_cuda_call(
+            cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device));
+        fprintf(stderr, "GPU compute capability: %d.%d\n", major, minor);
+
+        size_t global_mem = 0;
+        checked_cuda_call(cuDeviceTotalMem(&global_mem, device));
+        fprintf(stderr, "GPU global memory: %llu MB\n", (unsigned long long)(global_mem >> 20));
+        if (global_mem > (unsigned long long)4 * 1024 * 1024 * 1024L)
+            fprintf(stderr, "GPU 64-bit memory address support\n");
+    }
+#endif
 }
 
 /* Scratch */
@@ -364,12 +392,22 @@ static void dma_test(uint8_t zero_copy, uint8_t external_loopback, int data_widt
     uint8_t  run = (auto_rx_delay == 0);
 #endif
 
+#ifdef NV_DMA
+    CUdevice gpu_dev;
+    CUcontext gpu_ctx;
+    if (cuda_device_num >= 0) {
+        checked_cuda_call(cuInit(0));
+        checked_cuda_call(cuDeviceGet(&gpu_dev, cuda_device_num));
+        checked_cuda_call(cuCtxCreate(&gpu_ctx, 0, gpu_dev));
+    }
+#endif
+
     signal(SIGINT, intHandler);
 
     printf("\e[1m[> DMA loopback test:\e[0m\n");
     printf("---------------------\n");
 
-    if (litepcie_dma_init(&dma, litepcie_device, zero_copy))
+    if (litepcie_dma_init(&dma, litepcie_device, zero_copy, cuda_device_num >= 0))
         exit(1);
 
     /* Test loop. */
@@ -386,8 +424,11 @@ static void dma_test(uint8_t zero_copy, uint8_t external_loopback, int data_widt
         char *buf_wr;
         char *buf_rd;
 
+        // XXX: these individual read/write operations are very expensive
+        //      when backed by a GPU buffer, so disable data verification.
+
         /* DMA-TX Write. */
-        while (1) {
+        while (cuda_device_num == -1) {
             /* Get Write buffer. */
             buf_wr = litepcie_dma_next_write_buffer(&dma);
             /* Break when no buffer available for Write. */
@@ -398,7 +439,7 @@ static void dma_test(uint8_t zero_copy, uint8_t external_loopback, int data_widt
         }
 
         /* DMA-RX Read/Check */
-        while (1) {
+        while (cuda_device_num == -1) {
             /* Get Read buffer. */
             buf_rd = litepcie_dma_next_read_buffer(&dma);
             /* Break when no buffer available for Read. */
@@ -476,7 +517,10 @@ static void help(void)
            "\n"
            "options:\n"
            "-h                                Help.\n"
-           "-c device_num                     Select the device (default = 0).\n"
+           "-c device_num                     Select the FPGA device (default = 0).\n"
+#ifdef NV_DMA
+           "-g device_num                     Select the GPU device (default = -1, disabled).\n"
+#endif
            "-z                                Enable zero-copy DMA mode.\n"
            "-e                                Use external loopback (default = internal).\n"
            "-w data_width                     Width of data bus (default = 16).\n"
@@ -515,9 +559,11 @@ int main(int argc, char **argv)
     litepcie_device_zero_copy = 0;
     litepcie_device_external_loopback = 0;
 
+    cuda_device_num = -1;
+
     /* Parameters. */
     for (;;) {
-        c = getopt(argc, argv, "hc:w:zea");
+        c = getopt(argc, argv, "hc:g:w:zea");
         if (c == -1)
             break;
         switch(c) {
@@ -533,6 +579,11 @@ int main(int argc, char **argv)
         case 'z':
             litepcie_device_zero_copy = 1;
             break;
+#ifdef NV_DMA
+        case 'g':
+            cuda_device_num = atoi(optarg);
+            break;
+#endif
         case 'e':
             litepcie_device_external_loopback = 1;
             break;


### PR DESCRIPTION
This adds support for Nvidia RDMA to allow for PCIe P2P transfers between the a LiteX device and a Nvidia GPU.

The basic API is documented here:
https://docs.nvidia.com/cuda/gpudirect-rdma/index.html

This has been tested with the open source Nvidia drivers: https://github.com/NVIDIA/open-gpu-kernel-modules

The feature is selected in user/kernel by setting:
```
make NV_DMA=true
```

Co-authored-by: Tim Besard <tim.besard@gmail.com>
Co-authored-by: Elliot Saba <staticfloat@gmail.com>