### PR TITLE
Added DMA_ADDR_WIDTH constant to kc705.py bench to fix kernel driver

### DIFF
--- a/bench/kc705.py
+++ b/bench/kc705.py
@@ -90,6 +90,7 @@ class LitePCIeSoC(SoCMini):
             with_loopback  = True)
 
         self.add_constant("DMA_CHANNELS", 2)
+        self.add_constant("DMA_ADDR_WIDTH", 32)
 
         # MSI
         self.pcie_msi = LitePCIeMSI()


### PR DESCRIPTION
This fixes the following error trying to build the kc705 bench kernel driver
```
johnsimons@johnsimons-ubuntu:~/git/litex/litepcie/bench/build/kc705/driver/kernel$ sudo ./init.sh 
[sudo] password for johnsimons: 
Module not compiled
In file included from ./include/linux/pci-dma-compat.h:8,
                 from ./include/linux/pci.h:2461,
                 from /home/johnsimons/git/litex/litepcie/bench/build/kc705/driver/kernel/main.c:27:
/home/johnsimons/git/litex/litepcie/bench/build/kc705/driver/kernel/main.c: In function ‘litepcie_pci_probe’:
/home/johnsimons/git/litex/litepcie/bench/build/kc705/driver/kernel/main.c:1045:43: error: ‘DMA_ADDR_WIDTH’ undeclared (first use in this function)
 1045 |  ret = pci_set_dma_mask(dev, DMA_BIT_MASK(DMA_ADDR_WIDTH));
      |                                           ^~~~~~~~~~~~~~
./include/linux/dma-mapping.h:76:28: note: in definition of macro ‘DMA_BIT_MASK’
   76 | #define DMA_BIT_MASK(n) (((n) == 64) ? ~0ULL : ((1ULL<<(n))-1))
      |                            ^
/home/johnsimons/git/litex/litepcie/bench/build/kc705/driver/kernel/main.c:1045:43: note: each undeclared identifier is reported only once for each function it appears in
 1045 |  ret = pci_set_dma_mask(dev, DMA_BIT_MASK(DMA_ADDR_WIDTH));
      |                                           ^~~~~~~~~~~~~~
./include/linux/dma-mapping.h:76:28: note: in definition of macro ‘DMA_BIT_MASK’
   76 | #define DMA_BIT_MASK(n) (((n) == 64) ? ~0ULL : ((1ULL<<(n))-1))
      |                            ^
make[2]: *** [scripts/Makefile.build:297: /home/johnsimons/git/litex/litepcie/bench/build/kc705/driver/kernel/main.o] Error 1
make[1]: *** [Makefile:1914: /home/johnsimons/git/litex/litepcie/bench/build/kc705/driver/kernel] Error 2
make: *** [Makefile:14: litepcie.ko] Error 2

```