### PR TITLE
Add Configuration and PTM TLP support.

### DIFF
--- a/litepcie/common.py
+++ b/litepcie/common.py
@@ -95,6 +95,21 @@ def completion_layout(data_width, address_width=32):
     ]
     return EndpointDescription(layout)
 
+def ptm_layout(data_width):
+    layout = [
+        ("requester_id", 16), # Requester ID.
+        ("length",       16), # Length.
+        ("message_code", 16), # Message Code.
+
+        # Data Stream.
+        ("dat", data_width),
+
+        # Internal LitePCIe Routing/Identification.
+        ("channel", 8), # Crossbar's channel (Used for internal routing).
+    ]
+    return EndpointDescription(layout)
+
+
 def msi_layout():
     return [("dat", 8)]
 

--- a/litepcie/common.py
+++ b/litepcie/common.py
@@ -97,6 +97,8 @@ def completion_layout(data_width, address_width=32):
 
 def ptm_layout(data_width):
     layout = [
+        ("request",       1), # Request.
+        ("response",      1), # Response.
         ("requester_id", 16), # Requester ID.
         ("length",       16), # Length.
         ("message_code", 16), # Message Code.

--- a/litepcie/common.py
+++ b/litepcie/common.py
@@ -38,6 +38,25 @@ def phy_layout(data_width):
     ]
     return EndpointDescription(layout)
 
+def configuration_layout(data_width, address_width=32):
+    layout = [
+        # Request Parameters.
+        ("req_id",          16), # Requester ID.
+        ("we",               1), # Configuration type; 0 : Read / 1 : Write.
+        ("bus_number",       8), # Configuration Bus number.
+        ("device_no",        5), # Configuration Device number.
+        ("func",             3), # Configuration Function number.
+        ("ext_reg",          3), # Configuration Extended Register.
+        ("register_no",      6), # Configuration Register number.
+
+        # Data Stream.
+        ("dat", data_width),
+
+        # Internal LitePCIe Routing/Identification.
+        ("channel", 8), # Crossbar's channel (Used for internal routing).
+    ]
+    return EndpointDescription(layout)
+
 def request_layout(data_width, address_width=32):
     layout = [
         # Request Parameters.

--- a/litepcie/core/endpoint.py
+++ b/litepcie/core/endpoint.py
@@ -56,25 +56,25 @@ class LitePCIeEndpoint(LiteXModule):
                 data_width   = phy.data_width,
                 endianness   = endianness,
                 address_mask = phy.bar0_mask,
-                capabilities = ["REQUEST", "COMPLETION"] + (["PTM"] if with_ptm else []), # FIXME: Remove REQUEST?.
+                capabilities = ["COMPLETION"] + (["PTM"] if with_ptm else []),
             )
             self.req_depacketizer = req_depacketizer = LitePCIeTLPDepacketizer(
                 data_width   = phy.data_width,
                 endianness   = endianness,
                 address_mask = phy.bar0_mask,
-                capabilities = ["REQUEST", "COMPLETION"] + (["PTM"] if with_ptm else []), # FIXME: Remove COMPLETION?.
+                capabilities = ["REQUEST"] + (["PTM"] if with_ptm else []),
             )
             self.cmp_packetizer = cmp_packetizer = LitePCIeTLPPacketizer(
                 data_width    = phy.data_width,
                 endianness    = endianness,
                 address_width = address_width,
-                capabilities  = ["REQUEST", "COMPLETION"] + (["PTM"] if with_ptm else []), # FIXME: Remove REQUEST?.
+                capabilities  = ["COMPLETION"] + (["PTM"] if with_ptm else []),
             )
             self.req_packetizer = req_packetizer = LitePCIeTLPPacketizer(
                 data_width    = phy.data_width,
                 endianness    = endianness,
                 address_width = address_width,
-                capabilities  = ["REQUEST", "COMPLETION"] + (["PTM"] if with_ptm else []), # FIXME: Remove COMPLETION?.
+                capabilities  = ["REQUEST"] + (["PTM"] if with_ptm else []),
             )
             self.comb += [
                 phy.cmp_source.connect(cmp_depacketizer.sink),

--- a/litepcie/core/endpoint.py
+++ b/litepcie/core/endpoint.py
@@ -1,10 +1,12 @@
 #
 # This file is part of LitePCIe.
 #
-# Copyright (c) 2015-2022 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2015-2023 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
+
+from litex.gen import *
 
 from litex.soc.interconnect.csr import *
 
@@ -14,7 +16,7 @@ from litepcie.core.crossbar import LitePCIeCrossbar
 
 # LitePCIe Endpoint --------------------------------------------------------------------------------
 
-class LitePCIeEndpoint(Module):
+class LitePCIeEndpoint(LiteXModule):
     def __init__(self, phy, max_pending_requests=4, address_width=32, endianness="big",
         cmp_bufs_buffered = True,
         with_ptm          = False,
@@ -28,20 +30,18 @@ class LitePCIeEndpoint(Module):
 
         if hasattr(phy, "sink") and hasattr(phy, "source"):
             # Shared Request/Completion channels
-            depacketizer = LitePCIeTLPDepacketizer(
+            self.depacketizer = depacketizer = LitePCIeTLPDepacketizer(
                 data_width   = phy.data_width,
                 endianness   = endianness,
                 address_mask = phy.bar0_mask,
                 capabilities = ["REQUEST", "COMPLETION"] + (["PTM"] if with_ptm else []),
             )
-            packetizer   = LitePCIeTLPPacketizer(
+            self.packetizer = packetizer = LitePCIeTLPPacketizer(
                 data_width    = phy.data_width,
                 endianness    = endianness,
                 address_width = address_width,
                 capabilities  = ["REQUEST", "COMPLETION"] + (["PTM"] if with_ptm else []),
             )
-            self.submodules.depacketizer = depacketizer
-            self.submodules.packetizer   = packetizer
             self.comb += [
                 phy.source.connect(depacketizer.sink),
                 packetizer.source.connect(phy.sink)
@@ -52,34 +52,30 @@ class LitePCIeEndpoint(Module):
             cmp_source = depacketizer.cmp_source
         else:
             # Separate Request/Completion channels
-            cmp_depacketizer = LitePCIeTLPDepacketizer(
+            self.cmp_depacketizer = cmp_depacketizer = LitePCIeTLPDepacketizer(
                 data_width   = phy.data_width,
                 endianness   = endianness,
                 address_mask = phy.bar0_mask,
                 capabilities = ["REQUEST", "COMPLETION"] + (["PTM"] if with_ptm else []), # FIXME: Remove REQUEST?.
             )
-            req_depacketizer = LitePCIeTLPDepacketizer(
+            self.req_depacketizer = req_depacketizer = LitePCIeTLPDepacketizer(
                 data_width   = phy.data_width,
                 endianness   = endianness,
                 address_mask = phy.bar0_mask,
                 capabilities = ["REQUEST", "COMPLETION"] + (["PTM"] if with_ptm else []), # FIXME: Remove COMPLETION?.
             )
-            cmp_packetizer   = LitePCIeTLPPacketizer(
+            self.cmp_packetizer = cmp_packetizer = LitePCIeTLPPacketizer(
                 data_width    = phy.data_width,
                 endianness    = endianness,
                 address_width = address_width,
                 capabilities  = ["REQUEST", "COMPLETION"] + (["PTM"] if with_ptm else []), # FIXME: Remove REQUEST?.
             )
-            req_packetizer   = LitePCIeTLPPacketizer(
+            self.req_packetizer = req_packetizer = LitePCIeTLPPacketizer(
                 data_width    = phy.data_width,
                 endianness    = endianness,
                 address_width = address_width,
                 capabilities  = ["REQUEST", "COMPLETION"] + (["PTM"] if with_ptm else []), # FIXME: Remove COMPLETION?.
             )
-            self.submodules.cmp_depacketizer = cmp_depacketizer
-            self.submodules.req_depacketizer = req_depacketizer
-            self.submodules.cmp_packetizer   = cmp_packetizer
-            self.submodules.req_packetizer   = req_packetizer
             self.comb += [
                 phy.cmp_source.connect(cmp_depacketizer.sink),
                 phy.req_source.connect(req_depacketizer.sink),
@@ -93,13 +89,12 @@ class LitePCIeEndpoint(Module):
 
         # Crossbar ---------------------------------------------------------------------------------
 
-        crossbar = LitePCIeCrossbar(
+        self.crossbar = crossbar = LitePCIeCrossbar(
             data_width           = phy.data_width,
             address_width        = address_width,
             max_pending_requests = max_pending_requests,
-            cmp_bufs_buffered    = cmp_bufs_buffered
+            cmp_bufs_buffered    = cmp_bufs_buffered,
         )
-        self.submodules.crossbar = crossbar
 
         # Slave: HOST initiates the transactions ---------------------------------------------------
 

--- a/litepcie/tlp/common.py
+++ b/litepcie/tlp/common.py
@@ -70,8 +70,8 @@ cpl_dict = {
 tlp_common_header_length = 16
 # Define TLP common header fields.
 tlp_common_header_fields = {
-    "fmt":  HeaderField(byte=0*4, offset=29, width=2), # Format.
-    "type": HeaderField(byte=0*4, offset=24, width=5), # Type.
+    "fmt"  : HeaderField(byte=0*4, offset=29, width=2), # Format.
+    "type" : HeaderField(byte=0*4, offset=24, width=5), # Type.
 }
 # Define TLP common header
 tlp_common_header = Header(
@@ -84,20 +84,20 @@ tlp_common_header = Header(
 tlp_configuration_header_length = 16
 # Define TLP request header fields.
 tlp_configuration_header_fields = {
-    "fmt":          HeaderField(byte=0*4, offset=29, width= 2), # Format.
-    "type":         HeaderField(byte=0*4, offset=24, width= 5), # Type.
-    "td":           HeaderField(byte=0*4, offset=15, width= 1), # TLP Digest.
-    "ep":           HeaderField(byte=0*4, offset=14, width= 1), # Poisoned TLP.
+    "fmt"          : HeaderField(byte=0*4, offset=29, width= 2), # Format.
+    "type"         : HeaderField(byte=0*4, offset=24, width= 5), # Type.
+    "td"           : HeaderField(byte=0*4, offset=15, width= 1), # TLP Digest.
+    "ep"           : HeaderField(byte=0*4, offset=14, width= 1), # Poisoned TLP.
 
-    "requester_id": HeaderField(byte=1*4, offset=16, width=16), # Requester ID.
-    "tag":          HeaderField(byte=1*4, offset= 8, width= 8), # Tag.
-    "first_be":     HeaderField(byte=1*4, offset= 0, width= 4), # First Byte Enable.
+    "requester_id" : HeaderField(byte=1*4, offset=16, width=16), # Requester ID.
+    "tag"          : HeaderField(byte=1*4, offset= 8, width= 8), # Tag.
+    "first_be"     : HeaderField(byte=1*4, offset= 0, width= 4), # First Byte Enable.
 
-    "bus_number":   HeaderField(byte=2*4, offset=24, width= 8), # Bus number.
-    "device_no":    HeaderField(byte=2*4, offset=19, width= 5), # Device number.
-    "func":         HeaderField(byte=2*4, offset=16, width= 3), # Function number.
-    "ext_reg":      HeaderField(byte=2*4, offset= 8, width= 3), # Extended Register.
-    "register_no":  HeaderField(byte=2*4, offset= 2, width= 6), # Register number.
+    "bus_number"   : HeaderField(byte=2*4, offset=24, width= 8), # Bus number.
+    "device_no"    : HeaderField(byte=2*4, offset=19, width= 5), # Device number.
+    "func"         : HeaderField(byte=2*4, offset=16, width= 3), # Function number.
+    "ext_reg"      : HeaderField(byte=2*4, offset= 8, width= 3), # Extended Register.
+    "register_no"  : HeaderField(byte=2*4, offset= 2, width= 6), # Register number.
 }
 # Define TLP configuration header.
 tlp_configuration_header = Header(
@@ -110,20 +110,20 @@ tlp_configuration_header = Header(
 tlp_request_header_length = 16
 # Define TLP request header fields.
 tlp_request_header_fields = {
-    "fmt":          HeaderField(byte=0*4, offset=29, width= 2), # Format.
-    "type":         HeaderField(byte=0*4, offset=24, width= 5), # Type.
-    "tc":           HeaderField(byte=0*4, offset=20, width= 3), # Traffic Class.
-    "td":           HeaderField(byte=0*4, offset=15, width= 1), # TLP Digest.
-    "ep":           HeaderField(byte=0*4, offset=14, width= 1), # Poisoned TLP.
-    "attr":         HeaderField(byte=0*4, offset=12, width= 2), # Attributes.
-    "length":       HeaderField(byte=0*4, offset= 0, width=10), # Length.
+    "fmt"          : HeaderField(byte=0*4, offset=29, width= 2), # Format.
+    "type"         : HeaderField(byte=0*4, offset=24, width= 5), # Type.
+    "tc"           : HeaderField(byte=0*4, offset=20, width= 3), # Traffic Class.
+    "td"           : HeaderField(byte=0*4, offset=15, width= 1), # TLP Digest.
+    "ep"           : HeaderField(byte=0*4, offset=14, width= 1), # Poisoned TLP.
+    "attr"         : HeaderField(byte=0*4, offset=12, width= 2), # Attributes.
+    "length"       : HeaderField(byte=0*4, offset= 0, width=10), # Length.
 
-    "requester_id": HeaderField(byte=1*4, offset=16, width=16), # Requester ID.
-    "tag":          HeaderField(byte=1*4, offset= 8, width= 8), # Tag.
-    "last_be":      HeaderField(byte=1*4, offset= 4, width= 4), # Last Byte Enable.
-    "first_be":     HeaderField(byte=1*4, offset= 0, width= 4), # First Byte Enable.
+    "requester_id" : HeaderField(byte=1*4, offset=16, width=16), # Requester ID.
+    "tag"          : HeaderField(byte=1*4, offset= 8, width= 8), # Tag.
+    "last_be"      : HeaderField(byte=1*4, offset= 4, width= 4), # Last Byte Enable.
+    "first_be"     : HeaderField(byte=1*4, offset= 0, width= 4), # First Byte Enable.
 
-    "address":      HeaderField(byte=2*4, offset= 0, width=64), # Address.
+    "address"      : HeaderField(byte=2*4, offset= 0, width=64), # Address.
 }
 # Define TLP request header.
 tlp_request_header = Header(
@@ -136,22 +136,22 @@ tlp_request_header = Header(
 tlp_completion_header_length = 16
 # Define TLP completion header fields.
 tlp_completion_header_fields = {
-    "fmt":           HeaderField(byte=0*4, offset=29, width= 2), # Format.
-    "type":          HeaderField(byte=0*4, offset=24, width= 5), # Type.
-    "tc":            HeaderField(byte=0*4, offset=20, width= 3), # Traffic Class.
-    "td":            HeaderField(byte=0*4, offset=15, width= 1), # TLP Digest.
-    "ep":            HeaderField(byte=0*4, offset=14, width= 1), # Poisoned TLP.
-    "attr":          HeaderField(byte=0*4, offset=12, width= 2), # Attributes.
-    "length":        HeaderField(byte=0*4, offset= 0, width=10), # Length.
+    "fmt"           : HeaderField(byte=0*4, offset=29, width= 2), # Format.
+    "type"          : HeaderField(byte=0*4, offset=24, width= 5), # Type.
+    "tc"            : HeaderField(byte=0*4, offset=20, width= 3), # Traffic Class.
+    "td"            : HeaderField(byte=0*4, offset=15, width= 1), # TLP Digest.
+    "ep"            : HeaderField(byte=0*4, offset=14, width= 1), # Poisoned TLP.
+    "attr"          : HeaderField(byte=0*4, offset=12, width= 2), # Attributes.
+    "length"        : HeaderField(byte=0*4, offset= 0, width=10), # Length.
 
-    "completer_id":  HeaderField(byte=1*4, offset=16, width=16), # Completer ID.
-    "status":        HeaderField(byte=1*4, offset=13, width= 3), # Completion Status.
-    "bcm":           HeaderField(byte=1*4, offset=12, width= 1), # Byte Count Mismatch.
-    "byte_count":    HeaderField(byte=1*4, offset= 0, width=12), # Byte Count.
+    "completer_id"  : HeaderField(byte=1*4, offset=16, width=16), # Completer ID.
+    "status"        : HeaderField(byte=1*4, offset=13, width= 3), # Completion Status.
+    "bcm"           : HeaderField(byte=1*4, offset=12, width= 1), # Byte Count Mismatch.
+    "byte_count"    : HeaderField(byte=1*4, offset= 0, width=12), # Byte Count.
 
-    "requester_id":  HeaderField(byte=2*4, offset=16, width=16), # Requester ID.
-    "tag":           HeaderField(byte=2*4, offset= 8, width= 8), # Tag.
-    "lower_address": HeaderField(byte=2*4, offset= 0, width= 7), # Lower Address.
+    "requester_id"  : HeaderField(byte=2*4, offset=16, width=16), # Requester ID.
+    "tag"           : HeaderField(byte=2*4, offset= 8, width= 8), # Tag.
+    "lower_address" : HeaderField(byte=2*4, offset= 0, width= 7), # Lower Address.
 }
 # Define TLP completion header.
 tlp_completion_header = Header(
@@ -164,18 +164,18 @@ tlp_completion_header = Header(
 tlp_ptm_header_length = 8
 # Define TLP request header fields.
 tlp_ptm_header_fields = {
-    "fmt":          HeaderField(byte=0*4, offset=29, width= 2), # Format.
-    "type":         HeaderField(byte=0*4, offset=24, width= 5), # Type.
-    "tc":           HeaderField(byte=0*4, offset=20, width= 3), # Traffic Class.
-    "ln":           HeaderField(byte=0*4, offset=17, width= 1), # ?.
-    "th":           HeaderField(byte=0*4, offset=16, width= 1), # ?.
-    "td":           HeaderField(byte=0*4, offset=15, width= 1), # TLP Digest.
-    "ep":           HeaderField(byte=0*4, offset=14, width= 1), # Poisoned TLP.
-    "attr":         HeaderField(byte=0*4, offset=12, width= 2), # Attributes.
-    "length":       HeaderField(byte=0*4, offset= 0, width=10), # Length.
+    "fmt"          : HeaderField(byte=0*4, offset=29, width= 2), # Format.
+    "type"         : HeaderField(byte=0*4, offset=24, width= 5), # Type.
+    "tc"           : HeaderField(byte=0*4, offset=20, width= 3), # Traffic Class.
+    "ln"           : HeaderField(byte=0*4, offset=17, width= 1), # ?.
+    "th"           : HeaderField(byte=0*4, offset=16, width= 1), # ?.
+    "td"           : HeaderField(byte=0*4, offset=15, width= 1), # TLP Digest.
+    "ep"           : HeaderField(byte=0*4, offset=14, width= 1), # Poisoned TLP.
+    "attr"         : HeaderField(byte=0*4, offset=12, width= 2), # Attributes.
+    "length"       : HeaderField(byte=0*4, offset= 0, width=10), # Length.
 
-    "requester_id": HeaderField(byte=1*4, offset=16, width=16), # Requester ID.
-    "message_code": HeaderField(byte=1*4, offset=0,  width= 8), # Message Code.
+    "requester_id" : HeaderField(byte=1*4, offset=16, width=16), # Requester ID.
+    "message_code" : HeaderField(byte=1*4, offset=0,  width= 8), # Message Code.
 }
 # Define TLP PTM header.
 tlp_ptm_header = Header(

--- a/litepcie/tlp/common.py
+++ b/litepcie/tlp/common.py
@@ -74,6 +74,32 @@ tlp_common_header = Header(
     swap_field_bytes = False # No byte swapping required.
 )
 
+# Length of the TLP configuration header (in bytes).
+tlp_configuration_header_length = 16
+# Define TLP request header fields.
+tlp_configuration_header_fields = {
+    "fmt":          HeaderField(byte=0*4, offset=29, width= 2), # Format.
+    "type":         HeaderField(byte=0*4, offset=24, width= 5), # Type.
+    "td":           HeaderField(byte=0*4, offset=15, width= 1), # TLP Digest.
+    "ep":           HeaderField(byte=0*4, offset=14, width= 1), # Poisoned TLP.
+
+    "requester_id": HeaderField(byte=1*4, offset=16, width=16), # Requester ID.
+    "tag":          HeaderField(byte=1*4, offset= 8, width= 8), # Tag.
+    "first_be":     HeaderField(byte=1*4, offset= 0, width= 4), # First Byte Enable.
+
+    "bus_number":   HeaderField(byte=2*4, offset=24, width=8), # Bus number.
+    "device_no":    HeaderField(byte=2*4, offset=19, width=5), # Device number.
+    "func":         HeaderField(byte=2*4, offset=16, width=3), # Function number.
+    "ext_reg":      HeaderField(byte=2*4, offset= 8, width=3), # Extended Register.
+    "register_no":  HeaderField(byte=2*4, offset= 2, width=6), # Register number.
+}
+# Define TLP configuration header.
+tlp_configuration_header = Header(
+    fields           = tlp_configuration_header_fields,
+    length           = tlp_configuration_header_length,
+    swap_field_bytes = False # No byte swapping required.
+)
+
 # Length of the TLP request header (in bytes).
 tlp_request_header_length = 16
 # Define TLP request header fields.
@@ -200,6 +226,23 @@ def tlp_common_layout(data_width):
         EndpointDescription: Common TLP endpoint description.
     """
     layout = tlp_common_header.get_layout() + [
+        ("dat", data_width),   # Data field.
+        ("be",  data_width//8) # Byte Enable field.
+    ]
+    return EndpointDescription(layout)
+
+
+def tlp_configuration_layout(data_width):
+    """
+    Generate a configuration TLP endpoint description.
+
+    Parameters:
+        data_width (int): Width of the data (in bits).
+
+    Returns:
+        EndpointDescription: Configuration TLP endpoint description.
+    """
+    layout = tlp_configuration_header.get_layout() + [
         ("dat", data_width),   # Data field.
         ("be",  data_width//8) # Byte Enable field.
     ]

--- a/litepcie/tlp/common.py
+++ b/litepcie/tlp/common.py
@@ -16,46 +16,46 @@ max_request_size = 512
 
 # Format (fmt) field of different types of TLPs.
 fmt_dict = {
-    "mem_rd32": 0b00, # Memory Read Request  (32-bit).
-    "mem_rd64": 0b01, # Memory Read Request  (64-bit).
-    "mem_wr32": 0b10, # Memory Write Request (32-bit).
-    "mem_wr64": 0b11, # Memory Write Request (64-bit).
-    "cpld":     0b10, # Completion with Data.
-    "cpl":      0b00, # Completion without Data.
-    "cfg_rd0":  0b00, # Configuration Read Request (Type 0).
-    "cfg_wr0":  0b10, # Configuration Write Request (Type 0).
+    "mem_rd32" : 0b00, # Memory Read Request  (32-bit).
+    "mem_rd64" : 0b01, # Memory Read Request  (64-bit).
+    "mem_wr32" : 0b10, # Memory Write Request (32-bit).
+    "mem_wr64" : 0b11, # Memory Write Request (64-bit).
+    "cpld"     : 0b10, # Completion with Data.
+    "cpl"      : 0b00, # Completion without Data.
+    "cfg_rd0"  : 0b00, # Configuration Read Request (Type 0).
+    "cfg_wr0"  : 0b10, # Configuration Write Request (Type 0).
 }
 
 # Type (type) field of different types of TLPs.
 type_dict = {
-    "mem_rd32": 0b00000,  # Memory Read Request  (32-bit).
-    "mem_rd64": 0b00000,  # Memory Read Request  (64-bit).
-    "mem_wr32": 0b00000,  # Memory Write Request (32-bit).
-    "mem_wr64": 0b00000,  # Memory Write Request (64-bit).
-    "cpld":     0b01010,  # Completion with Data.
-    "cpl":      0b01010,  # Completion without Data.
-    "cfg_rd0":  0b00101,   # Configuration Read Request (Type 0).
-    "cfg_wr0":  0b00101,   # Configuration Write Request (Type 0).
+    "mem_rd32" : 0b00000, # Memory Read Request  (32-bit).
+    "mem_rd64" : 0b00000, # Memory Read Request  (64-bit).
+    "mem_wr32" : 0b00000, # Memory Write Request (32-bit).
+    "mem_wr64" : 0b00000, # Memory Write Request (64-bit).
+    "cpld"     : 0b01010, # Completion with Data.
+    "cpl"      : 0b01010, # Completion without Data.
+    "cfg_rd0"  : 0b00101, # Configuration Read Request (Type 0).
+    "cfg_wr0"  : 0b00101, # Configuration Write Request (Type 0).
 }
 
 # Format and Type fields for different types of TLPs.
 fmt_type_dict = {
-    "mem_rd32": 0b00_00000, # Memory Read Request  (32-bit).
-    "mem_rd64": 0b01_00000, # Memory Read Request  (64-bit).
-    "mem_wr32": 0b10_00000, # Memory Write Request (32-bit).
-    "mem_wr64": 0b11_00000, # Memory Write Request (64-bit).
-    "cpld":     0b10_01010, # Completion with Data.
-    "cpl":      0b00_01010, # Completion without Data.
-    "cfg_rd0":  0b00_00101, # Configuration Read Request (Type 0).
-    "cfg_wr0":  0b10_00101, # Configuration Write Request (Type 0).
+    "mem_rd32" : 0b00_00000, # Memory Read Request  (32-bit).
+    "mem_rd64" : 0b01_00000, # Memory Read Request  (64-bit).
+    "mem_wr32" : 0b10_00000, # Memory Write Request (32-bit).
+    "mem_wr64" : 0b11_00000, # Memory Write Request (64-bit).
+    "cpld"     : 0b10_01010, # Completion with Data.
+    "cpl"      : 0b00_01010, # Completion without Data.
+    "cfg_rd0"  : 0b00_00101, # Configuration Read Request (Type 0).
+    "cfg_wr0"  : 0b10_00101, # Configuration Write Request (Type 0).
 }
 
 # Completion Status (cpl) field of Completion TLPs.
 cpl_dict = {
-    "sc":  0b000, # Successful Completion.
-    "ur":  0b001, # Unsupported Request.
-    "crs": 0b010, # Configuration Request Retry Status.
-    "ca":  0b011, # Completer Abort.
+    "sc"  : 0b000, # Successful Completion.
+    "ur"  : 0b001, # Unsupported Request.
+    "crs" : 0b010, # Configuration Request Retry Status.
+    "ca"  : 0b011, # Completer Abort.
 }
 
 # Headers ------------------------------------------------------------------------------------------
@@ -87,11 +87,11 @@ tlp_configuration_header_fields = {
     "tag":          HeaderField(byte=1*4, offset= 8, width= 8), # Tag.
     "first_be":     HeaderField(byte=1*4, offset= 0, width= 4), # First Byte Enable.
 
-    "bus_number":   HeaderField(byte=2*4, offset=24, width=8), # Bus number.
-    "device_no":    HeaderField(byte=2*4, offset=19, width=5), # Device number.
-    "func":         HeaderField(byte=2*4, offset=16, width=3), # Function number.
-    "ext_reg":      HeaderField(byte=2*4, offset= 8, width=3), # Extended Register.
-    "register_no":  HeaderField(byte=2*4, offset= 2, width=6), # Register number.
+    "bus_number":   HeaderField(byte=2*4, offset=24, width= 8), # Bus number.
+    "device_no":    HeaderField(byte=2*4, offset=19, width= 5), # Device number.
+    "func":         HeaderField(byte=2*4, offset=16, width= 3), # Function number.
+    "ext_reg":      HeaderField(byte=2*4, offset= 8, width= 3), # Extended Register.
+    "register_no":  HeaderField(byte=2*4, offset= 2, width= 6), # Register number.
 }
 # Define TLP configuration header.
 tlp_configuration_header = Header(

--- a/litepcie/tlp/common.py
+++ b/litepcie/tlp/common.py
@@ -312,34 +312,17 @@ def tlp_completion_layout(data_width):
     ]
     return EndpointDescription(layout)
 
-def tlp_ptm_request_layout(data_width):
+def tlp_ptm_layout(data_width):
     """
-    Generate a request TLP endpoint description.
+    Generate a PTM TLP endpoint description.
 
     Parameters:
         data_width (int): Width of the data (in bits).
 
     Returns:
-        EndpointDescription: Request TLP endpoint description.
+        EndpointDescription: PTM TLP endpoint description.
     """
-    layout = tlp_request_header.get_layout() + [
-        ("dat", data_width),   # Data field.
-        ("be",  data_width//8) # Byte Enable field.
-    ]
-    return EndpointDescription(layout)
-
-
-def tlp_completion_layout(data_width):
-    """
-    Generate a completion TLP endpoint description.
-
-    Parameters:
-        data_width (int): Width of the data (in bits).
-
-    Returns:
-        EndpointDescription: Completion TLP endpoint description.
-    """
-    layout = tlp_completion_header.get_layout() + [
+    layout = tlp_ptm_header.get_layout() + [
         ("dat", data_width),   # Data field.
         ("be",  data_width//8) # Byte Enable field.
     ]


### PR DESCRIPTION
- Rework Packetizer/Depacketizer to be more modular (and allow individual selection of capabilities: Request, Completion, Configuration, PTM TLPs).
- Add Configuration TLP definitions/layouts.
- Add PTM TLP definitions/layouts.
- Implement Configuration support in Depacketizer (not required in Packetizer since returning Completion).
- Implement PTM support in Packetizer/Depacketizer.

For now, Configuration and PTM TLPs can now just be sent/received to/from  the User logic. Logic to handle this still has to be done and integrated.

> Note: As a bonus, making Packetizer/Depacketizer more modular allow some optimization on Ultrascale(+) were we can only select Completion or Request support (see  https://github.com/enjoy-digital/litepcie/commit/33c52fc2b339464bf89e6b7f5e7f9e6ccfc2e06b).