### PR TITLE
litepcie/software/kernel: updated main.c to support Linux kernel 6.5

### DIFF
--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -1282,7 +1282,11 @@ static int __init litepcie_module_init(void)
 {
 	int ret;
 
-	litepcie_class = class_create(THIS_MODULE, LITEPCIE_NAME);
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0)
+		litepcie_class = class_create(THIS_MODULE, LITEPCIE_NAME);
+	#else
+		litepcie_class = class_create(LITEPCIE_NAME);
+	#endif
 	if (!litepcie_class) {
 		ret = -EEXIST;
 		pr_err(" Failed to create class\n");


### PR DESCRIPTION
Linux Kernel 6.5 has slightly different syntax related to creating a class, which I ifdef-ed so the the driver will compile against the latest kernels.