### PR TITLE
phy/usppciephy,uspciephy: Disable straddle mode for request completion

### DIFF
--- a/litepcie/phy/uspciephy.py
+++ b/litepcie/phy/uspciephy.py
@@ -382,7 +382,7 @@ class USPCIEPHY(LiteXModule):
                 "PL_LINK_CAP_MAX_LINK_WIDTH"   : f"X{self.nlanes}",
                 "PL_LINK_CAP_MAX_LINK_SPEED"   : "8.0_GT/s", # CHECKME.
                 "axisten_if_width"             : f"{self.pcie_data_width}_bit",
-                "AXISTEN_IF_RC_STRADDLE"       : True,
+                "AXISTEN_IF_RC_STRADDLE"       : False,
                 "PF0_DEVICE_ID"                : 8030 + self.nlanes,
                 "axisten_freq"                 : 250, # CHECKME.
                 "axisten_if_enable_client_tag" : True,

--- a/litepcie/phy/usppciephy.py
+++ b/litepcie/phy/usppciephy.py
@@ -383,7 +383,7 @@ class USPPCIEPHY(LiteXModule):
                 "PL_LINK_CAP_MAX_LINK_WIDTH"   : f"X{self.nlanes}",
                 "PL_LINK_CAP_MAX_LINK_SPEED"   : "8.0_GT/s", # CHECKME.
                 "axisten_if_width"             : f"{self.pcie_data_width}_bit",
-                "AXISTEN_IF_RC_STRADDLE"       : True,
+                "AXISTEN_IF_RC_STRADDLE"       : False,
                 "PF0_DEVICE_ID"                : 9030 + self.nlanes,
                 "axisten_freq"                 : 250, # CHECKME.
                 "axisten_if_enable_client_tag" : True,


### PR DESCRIPTION
This is not supported by the adaptation layer and causes troubles when trying to issue read requests.

Fixes #125 