### PR TITLE
software/kernel/liteuart: fix linux/of_platform.h no longer including…

### DIFF
--- a/litepcie/software/kernel/liteuart.c
+++ b/litepcie/software/kernel/liteuart.c
@@ -3,6 +3,7 @@
  * LiteUART serial controller (LiteX) Driver
  *
  * Copyright (C) 2019-2020 Antmicro <www.antmicro.com>
+ * Copyright (C) 2024 John Simons <jammsimons@gmail.com>
  */
 
 #include <linux/console.h>
@@ -11,6 +12,7 @@
 #include <linux/of.h>
 #include <linux/of_address.h>
 #include <linux/of_platform.h>
+#include <linux/platform_device.h>
 #include <linux/serial.h>
 #include <linux/serial_core.h>
 #include <linux/slab.h>


### PR DESCRIPTION
… linux/platform_device.h in latest kernel

Small fix for kernel 6.8