### PR TITLE
phy/usppciephy: Use double wide axis for gen4

### DIFF
--- a/litepcie/phy/usppciephy.py
+++ b/litepcie/phy/usppciephy.py
@@ -3,6 +3,7 @@
 #
 # Copyright (c) 2020-2023 Enjoy-Digital <enjoy-digital.fr>
 # Copyright (c) 2022 Sylvain Munaut <tnt@246tNt.com>
+# Copyright (c) 2024 John Simons <jammsimons@gmail.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
@@ -415,10 +416,14 @@ class USPPCIEPHY(LiteXModule):
 
         verilog_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "xilinx_usp")
         platform.add_source(os.path.join(verilog_path, "axis_iff.v"))
-        platform.add_source(os.path.join(verilog_path, f"s_axis_rq_adapt_x{self.nlanes}.v"))
-        platform.add_source(os.path.join(verilog_path, f"m_axis_rc_adapt_x{self.nlanes}.v"))
-        platform.add_source(os.path.join(verilog_path, f"m_axis_cq_adapt_x{self.nlanes}.v"))
-        platform.add_source(os.path.join(verilog_path, f"s_axis_cc_adapt_x{self.nlanes}.v"))
+        
+        nvlanes = {"gen3": self.nlanes, "gen4": self.nlanes*2}[self.speed]
+                
+        platform.add_source(os.path.join(verilog_path, f"s_axis_rq_adapt_x{nvlanes}.v"))
+        platform.add_source(os.path.join(verilog_path, f"m_axis_rc_adapt_x{nvlanes}.v"))
+        platform.add_source(os.path.join(verilog_path, f"m_axis_cq_adapt_x{nvlanes}.v"))
+        platform.add_source(os.path.join(verilog_path, f"s_axis_cc_adapt_x{nvlanes}.v"))
+            
         platform.add_source(os.path.join(verilog_path, "pcie_usp_support.v"))
 
     # External Hard IP -----------------------------------------------------------------------------

--- a/litepcie/software/kernel/liteuart.c
+++ b/litepcie/software/kernel/liteuart.c
@@ -3,6 +3,7 @@
  * LiteUART serial controller (LiteX) Driver
  *
  * Copyright (C) 2019-2020 Antmicro <www.antmicro.com>
+ * Copyright (C) 2024 John Simons <jammsimons@gmail.com>
  */
 
 #include <linux/console.h>
@@ -11,6 +12,7 @@
 #include <linux/of.h>
 #include <linux/of_address.h>
 #include <linux/of_platform.h>
+#include <linux/platform_device.h>
 #include <linux/serial.h>
 #include <linux/serial_core.h>
 #include <linux/slab.h>

--- a/litepcie/tlp/packetizer.py
+++ b/litepcie/tlp/packetizer.py
@@ -2,6 +2,7 @@
 # This file is part of LitePCIe.
 #
 # Copyright (c) 2015-2023 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2024 John Simons <jammsimons@gmail.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
@@ -804,7 +805,7 @@ class LitePCIeTLPPacketizer(LiteXModule):
 
             # On Ultrascale(+) / 256-bit, force to 64-bit (for 4DWs format).
             try:
-                force_64b = (LiteXContext.platform.device[:4] in ["xcku", "xcvu", "xczu"]) and (data_width in [256])
+                force_64b = (LiteXContext.platform.device[:4] in ["xcku", "xcvu", "xczu", 'xcau']) and (data_width in [256])
             except:
                 force_64b = False
 


### PR DESCRIPTION
This completes gen4 support on the gateware side.

![Screenshot from 2024-04-30 03-24-05](https://github.com/enjoy-digital/litepcie/assets/537075/589fcab5-a671-47c3-a1af-2bf3b509cd4d)
![Screenshot from 2024-04-30 03-24-18](https://github.com/enjoy-digital/litepcie/assets/537075/4a566f73-cfdc-4b97-a0cd-5b22b1cf0554)
