### PR TITLE
Remove usage of `distutils`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ enjoy-digital.fr.
 
 [> Getting started
 ------------------
-1. Install Python 3.6+ and FPGA vendor's development tools.
+1. Install Python 3.8+ and FPGA vendor's development tools.
 2. Install LiteX and the cores by following the LiteX's wiki [installation guide](https://github.com/enjoy-digital/litex/wiki/Installation).
 3. You can find examples of integration of the core with LiteX in LiteX-Boards and in the examples directory.
 

--- a/litepcie/software/__init__.py
+++ b/litepcie/software/__init__.py
@@ -1,5 +1,5 @@
 import os
-from distutils.dir_util import copy_tree
+from shutil import copytree
 
 from litex.build import tools
 
@@ -8,7 +8,7 @@ from litex.soc.integration.export import get_csr_header, get_soc_header, get_mem
 
 def copy_litepcie_software(dst):
     src = os.path.abspath(os.path.dirname(__file__))
-    copy_tree(src, dst)
+    copytree(src, dst, dirs_exist_ok=True)
 
 def generate_litepcie_software_headers(soc, dst):
     csr_header = get_csr_header(soc.csr_regions, soc.constants, with_access_functions=False)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     download_url                  = "https://github.com/enjoy-digital/litepcie",
     test_suite                    = "test",
     license                       = "BSD",
-    python_requires               = "~=3.7",
+    python_requires               = "~=3.8",
     install_requires              = ["pyyaml", "litex"],
     extras_require                = {
         "develop": [


### PR DESCRIPTION
`distutils` was removed in Python 3.12, causing litepcie to crash when trying to use it.