### PR TITLE
Adding support for BPI flash for YPCB board

### DIFF
--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -635,7 +635,7 @@ static unsigned int litepcie_poll(struct file *file, poll_table *wait)
 	return mask;
 }
 
-#ifdef CSR_FLASH_BASE
+#ifdef CSR_FLASH_SPI_CONTROL_ADDR
 /* SPI */
 
 #define SPI_TIMEOUT 100000 /* in us */
@@ -692,7 +692,7 @@ static long litepcie_ioctl(struct file *file, unsigned int cmd,
 		}
 	}
 	break;
-#ifdef CSR_FLASH_BASE
+#ifdef CSR_FLASH_SPI_CONTROL_ADDR
 	case LITEPCIE_IOCTL_FLASH:
 	{
 		struct litepcie_ioctl_flash m;

--- a/litepcie/software/user/liblitepcie/litepcie_flash.h
+++ b/litepcie/software/user/liblitepcie/litepcie_flash.h
@@ -28,6 +28,29 @@
 
 #define FLASH_SECTOR_SIZE (1 << 16)
 
+/* BPI (Intel CFI) commands */
+#define BPI_CMD_READ_ARRAY    0x00FF
+#define BPI_CMD_READ_ID       0x0090
+#define BPI_CMD_READ_STATUS   0x0070
+#define BPI_CMD_CLEAR_STATUS  0x0050
+#define BPI_CMD_PROGRAM       0x0041  /* Single-word program */
+#define BPI_CMD_BUFFERED_PRG  0x00E9  /* Buffered program setup */
+#define BPI_CMD_CONFIRM       0x00D0
+#define BPI_CMD_BLOCK_ERASE   0x0020
+#define BPI_CMD_UNLOCK_BLOCK  0x0060
+
+/* BPI status register bits */
+#define BPI_SR_READY      0x0080
+#define BPI_SR_ERASE_ERR  0x0020
+#define BPI_SR_PROG_ERR   0x0010
+
+#define BPI_BLOCK_SIZE    (256 * 1024)  /* 256KB blocks */
+
+/* BPI control/status bits */
+#define BPI_CTRL_START  (1 << 0)
+#define BPI_CTRL_RW     (1 << 1)
+#define BPI_STATUS_DONE (1 << 0)
+
 uint8_t litepcie_flash_read(int fd, uint32_t addr);
 int litepcie_flash_get_erase_block_size(int fd);
 int litepcie_flash_write(int fd,


### PR DESCRIPTION
Add BPI (parallel NOR) flash support alongside the existing SPI flash path. Tested on YPCB-00338-1P1 with Micron MT28GU512AAA BPI x16 flash. Enables flash read/write/erase over PCIe via CSR registers