### PR TITLE
phy/s7pciephy.py: expose MMCM/Device speedgrade

### DIFF
--- a/litepcie/phy/s7pciephy.py
+++ b/litepcie/phy/s7pciephy.py
@@ -28,16 +28,17 @@ class S7PCIEPHY(LiteXModule):
     }
     def __init__(self, platform, pads, data_width=64,  cd="sys",
         # PCIe hardblock parameters.
-        pcie_data_width               = None,
-        refclk_freq                   = 100e6,
-        bar0_size                     = 0x100000,
-        msi_type                      = "msi",
-        with_ptm                      = False,
-        mode                          = "Endpoint",
-        with_perst_refclk_gating      = False,
+        pcie_data_width              = None,
+        refclk_freq                  = 100e6,
+        bar0_size                    = 0x100000,
+        msi_type                     = "msi",
+        with_ptm                     = False,
+        mode                         = "Endpoint",
+        with_perst_refclk_gating     = False,
         # MMCM parameters.
-        mmcm_clk125_buf               = "bufg",
-        mmcm_clk250_buf               = "bufg",
+        mmcm_clk125_buf              = "bufg",
+        mmcm_clk250_buf              = "bufg",
+        mmcm_speedgrade              = -2,
     ):
         # Streams ----------------------------------------------------------------------------------
         self.sink   = stream.Endpoint(phy_layout(data_width))
@@ -188,7 +189,7 @@ class S7PCIEPHY(LiteXModule):
         # MMCM.
         userclk1_freq = {1:125e6, 2:125e6, 4:250e6, 8:500e6}[nlanes]
         userclk2_freq = {1:125e6, 2:125e6, 4:125e6, 8:250e6}[nlanes]
-        self.mmcm = mmcm = S7MMCM(speedgrade=-2)
+        self.mmcm = mmcm = S7MMCM(speedgrade=mmcm_speedgrade)
         self.specials += Instance("BUFG",
             i_I = pipe_txoutclk,
             o_O = pipe_txoutclk_bufg,


### PR DESCRIPTION
`S7MMCM` used in this core has its speedgrade parameter hardcoded to `-2`.
This produces built failure when the Device has a speedgrade == `-1`.

This commit adds a new parameter to allows caller to specify explicitly the speedgrade.