### PR TITLE
tlp: Add support for 32-bit datapath.

### DIFF
--- a/litepcie/frontend/wishbone.py
+++ b/litepcie/frontend/wishbone.py
@@ -16,6 +16,10 @@ from litepcie.common import *
 # Helpers ------------------------------------------------------------------------------------------
 
 def map_wishbone_dat(address, data, wishbone_dat, qword_aligned=False):
+    # Exit early if data width is 32 bits to avoid a zero-width slice.
+    if len(data) == 32:
+        return [wishbone_dat.eq(data)]
+
     return [
         If(qword_aligned,
             If(address[2],

--- a/litepcie/tlp/depacketizer.py
+++ b/litepcie/tlp/depacketizer.py
@@ -120,6 +120,76 @@ class _LitePCIeTLPHeaderExtracter(LiteXModule):
             )
         )
 
+# LitePCIeTLPHeaderExtracter32b --------------------------------------------------------------------
+
+class LitePCIeTLPHeaderExtracter32b(LiteXModule):
+    def __init__(self):
+        self.sink   = sink   = stream.Endpoint(phy_layout(32))
+        self.source = source = stream.Endpoint(tlp_raw_layout(32))
+
+        # # #
+
+        first = Signal()
+        fmt = Signal(2)
+
+        self.comb += [
+            source.first.eq(first),
+            source.dat.eq(sink.dat),
+            fmt.eq(source.header[29:31]),
+        ]
+
+        self.fsm = fsm = FSM(reset_state="HEADER_0")
+        fsm.act("HEADER_0",
+            NextValue(first, 1),
+            sink.ready.eq(1),
+            If(sink.valid,
+                NextValue(source.header[32*0:32*1], sink.dat),
+                NextState("HEADER_1"),
+            )
+        )
+        fsm.act("HEADER_1",
+            sink.ready.eq(1),
+            If(sink.valid,
+                NextValue(source.header[32*1:32*2], sink.dat),
+                NextState("HEADER_2"),
+            )
+        )
+        fsm.act("HEADER_2",
+            sink.ready.eq(1),
+            If(sink.valid,
+                NextValue(source.header[32*2:32*3], sink.dat),
+                NextState("HEADER_3"),
+                If(fmt == 0, NextState("NO_DATA")),
+                If(fmt == 2, NextState("DATA")),
+            )
+        )
+        fsm.act("HEADER_3",
+            sink.ready.eq(1),
+            If(sink.valid,
+                NextValue(source.header[32*3:32*4], sink.dat),
+                NextState("DATA"),
+                If(fmt == 1, NextState("NO_DATA")),
+            )
+        )
+        fsm.act("DATA",
+            sink.ready.eq(source.ready),
+            source.valid.eq(sink.valid),
+            source.last.eq(sink.last),
+            source.be.eq(sink.be),
+            If(source.valid & source.ready,
+                NextValue(first, 0),
+                If(source.last, NextState("HEADER_0")),
+            )
+        )
+        fsm.act("NO_DATA",
+            source.valid.eq(1),
+            source.last.eq(1),
+            source.be.eq(0),
+            If(source.ready,
+                NextState("HEADER_0"),
+            )
+        )
+
 # LitePCIeTLPHeaderExtracter64b --------------------------------------------------------------------
 
 class LitePCIeTLPHeaderExtracter64b(LiteXModule):
@@ -234,6 +304,7 @@ class LitePCIeTLPDepacketizer(LiteXModule):
         # Extract RAW Header from Sink -------------------------------------------------------------
 
         header_extracter_cls = {
+             32 : LitePCIeTLPHeaderExtracter32b,
              64 : LitePCIeTLPHeaderExtracter64b,
             128 : LitePCIeTLPHeaderExtracter128b,
             256 : LitePCIeTLPHeaderExtracter256b,

--- a/litepcie/tlp/packetizer.py
+++ b/litepcie/tlp/packetizer.py
@@ -262,6 +262,130 @@ class LitePCIeTLPHeaderInserter4DWs(_LitePCIeTLPHeaderInserterNDWs):
         )
 
 
+# LitePCIeTLPHeaderInserter32b ---------------------------------------------------------------------
+
+
+class LitePCIeTLPHeaderInserter32b3DWs(LiteXModule):
+    def __init__(self):
+        self.sink   = sink   = stream.Endpoint(tlp_raw_layout(32))
+        self.source = source = stream.Endpoint(phy_layout(32))
+
+        # # #
+
+        count = Signal(2)
+
+        self.fsm = fsm = FSM(reset_state="HEADER")
+        fsm.act("HEADER",
+            sink.ready.eq(1),
+            If(sink.valid & sink.first,
+                sink.ready.eq(0),
+                source.valid.eq(1),
+                source.first.eq((count == 0) & sink.first),
+                source.last.eq((count == 2) & sink.last & (sink.be == 0)),
+                If(count == 0,
+                    source.dat.eq(sink.header[32*0:]),
+                    source.be.eq(0xf),
+                ),
+                If(count == 1,
+                    source.dat.eq(sink.header[32*1:]),
+                    source.be.eq(0xf),
+                ),
+                If(count == 2,
+                    source.dat.eq(sink.header[32*2:]),
+                    source.be.eq(0xf),
+                ),
+                If(source.valid & source.ready,
+                    NextValue(count, count + 1),
+                    If(count == 2,
+                        NextValue(count, 0),
+                        sink.ready.eq(source.last),
+                        If(~source.last,
+                            NextState("DATA")
+                        )
+                    )
+                )
+            )
+        )
+        fsm.act("DATA",
+            sink.ready.eq(source.ready),
+            source.valid.eq(sink.valid),
+            source.last.eq(sink.last),
+            source.dat.eq(sink.dat),
+            source.be.eq(sink.be),
+
+            If(source.valid & source.ready & source.last,
+                NextState("HEADER")
+            )
+        )
+
+class LitePCIeTLPHeaderInserter32b4DWs(LiteXModule):
+    def __init__(self):
+        self.sink   = sink   = stream.Endpoint(tlp_raw_layout(32))
+        self.source = source = stream.Endpoint(phy_layout(32))
+
+        # # #
+
+        count = Signal(2)
+
+        self.fsm = fsm = FSM(reset_state="HEADER")
+        fsm.act("HEADER",
+            sink.ready.eq(1),
+            If(sink.valid & sink.first,
+                sink.ready.eq(0),
+                source.valid.eq(1),
+                source.first.eq((count == 0) & sink.first),
+                source.last.eq((count == 3) & sink.last & (sink.be == 0)),
+                If(count == 0,
+                    source.dat.eq(sink.header[32*0:]),
+                    source.be.eq(0xf),
+                ),
+                If(count == 1,
+                    source.dat.eq(sink.header[32*1:]),
+                    source.be.eq(0xf),
+                ),
+                If(count == 2,
+                    source.dat.eq(sink.header[32*2:]),
+                    source.be.eq(0xf),
+                ),
+                If(count == 3,
+                    source.dat.eq(sink.header[32*3:]),
+                    source.be.eq(0xf),
+                ),
+                If(source.valid & source.ready,
+                    NextValue(count, count + 1),
+                    If(count == 3,
+                        NextValue(count, 0),
+                        sink.ready.eq(source.last),
+                        If(~source.last,
+                            NextState("DATA")
+                        )
+                    )
+                )
+            )
+        )
+        fsm.act("DATA",
+            sink.ready.eq(source.ready),
+            source.valid.eq(sink.valid),
+            source.last.eq(sink.last),
+            source.dat.eq(sink.dat),
+            source.be.eq(sink.be),
+
+            If(source.valid & source.ready & source.last,
+                NextState("HEADER")
+            )
+        )
+
+
+class LitePCIeTLPHeaderInserter32b(LitePCIeTLPHeaderInserter3DWs4DWs):
+    def __init__(self, fmt):
+        LitePCIeTLPHeaderInserter3DWs4DWs.__init__(self,
+            data_width               = 32,
+            header_inserter_3dws_cls = LitePCIeTLPHeaderInserter32b3DWs,
+            header_inserter_4dws_cls = LitePCIeTLPHeaderInserter32b4DWs,
+            fmt                      = fmt,
+        )
+
+
 # LitePCIeTLPHeaderInserter64b ---------------------------------------------------------------------
 
 
@@ -787,6 +911,7 @@ class LitePCIeTLPPacketizer(LiteXModule):
 
         # Insert header ----------------------------------------------------------------------------
         header_inserter_cls = {
+            32 : LitePCIeTLPHeaderInserter32b,
             64 : LitePCIeTLPHeaderInserter64b,
            128 : LitePCIeTLPHeaderInserter128b,
            256 : LitePCIeTLPHeaderInserter256b,

--- a/test/test_header_extracter.py
+++ b/test/test_header_extracter.py
@@ -16,6 +16,7 @@ from litex.soc.interconnect import stream
 from litepcie.tlp.common import fmt_dict, tlp_raw_layout, phy_layout
 
 from litepcie.tlp.depacketizer import (
+    LitePCIeTLPHeaderExtracter32b,
     LitePCIeTLPHeaderExtracter64b,
     LitePCIeTLPHeaderExtracter128b,
     LitePCIeTLPHeaderExtracter256b,
@@ -56,15 +57,11 @@ def _fmt_for_header_dws(header_dws):
 def _model_phy_packet_beats(data_width, header_dws, header_4dws, payload_dws, payload_be_nibbles):
     """
     Build PHY beats that look like a packet *after* header insertion (what the extracter consumes).
-
-    The current RTL header extracters always capture 4 header DWs from the PHY stream.
-    So even when we conceptually test "3DW", PHY still carries a 4DW header with DW3=0.
     """
     n = _dws_per_beat(data_width)
 
-    # PHY always has 4 header DWs for the extracter.
-    hdr_stream = list(header_4dws[:header_dws]) + [0x00000000] * (4 - header_dws)
-    hdr_be     = [0xF] * 4
+    hdr_stream = list(header_4dws[:header_dws])
+    hdr_be     = [0xF] * header_dws
 
     in_dws = list(hdr_stream) + list(payload_dws)
     in_be  = list(hdr_be)     + list(payload_be_nibbles)
@@ -115,6 +112,27 @@ def _model_extracter_output_beats(data_width, phy_beats):
     """
     n = _dws_per_beat(data_width)
     out_beats = []
+
+    if data_width == 32:
+        header_dws = 4 if bool(phy_beats[0]["dws"][0] & (1 << 29)) else 3
+        if len(phy_beats) <= header_dws:
+            out_beats.append({
+                "first": 1,
+                "last" : 1,
+                "dws"  : [0],
+                "be"   : [0],
+            })
+            return out_beats
+
+        for i in range(header_dws, len(phy_beats)):
+            b0 = phy_beats[i]
+            out_beats.append({
+                "first": 1 if i == header_dws else 0,
+                "last" : b0["last"],
+                "dws"  : b0["dws"],
+                "be"   : b0["be"],
+            })
+        return out_beats
 
     if data_width == 64:
         if len(phy_beats) <= 1:
@@ -176,7 +194,10 @@ def _model_extracter_output_beats(data_width, phy_beats):
 
 def _model_extracter_header_value(data_width, phy_beats):
     # What RTL captures as header.
-    if data_width == 64:
+    if data_width == 32:
+        header_dws = 4 if bool(phy_beats[0]["dws"][0] & (1 << 29)) else 3
+        hdr = [phy_beats[i]["dws"][0] if i < header_dws else 0 for i in range(4)]
+    elif data_width == 64:
         b0 = phy_beats[0]["dws"]
         b1 = phy_beats[1]["dws"] if len(phy_beats) > 1 else [0, 0]
         hdr = [b0[0], b0[1], b1[0], b1[1]]
@@ -192,6 +213,7 @@ class _HeaderExtracterDUT(LiteXModule):
         self.source = stream.Endpoint(tlp_raw_layout(data_width))
 
         cls = {
+             32 : LitePCIeTLPHeaderExtracter32b,
              64 : LitePCIeTLPHeaderExtracter64b,
             128 : LitePCIeTLPHeaderExtracter128b,
             256 : LitePCIeTLPHeaderExtracter256b,
@@ -208,6 +230,16 @@ class _HeaderExtracterDUT(LiteXModule):
 
 class TestLitePCIeTLPHeaderExtracter(unittest.TestCase):
     def _run_case(self, data_width, header_dws, header_4dws, payload_dws, payload_be_nibbles):
+        # Ensure format bits in header are consistent with with header and payload sizes.
+        if header_dws == 4:
+            header_4dws[0] |= (1 << 29)
+        else:
+            header_4dws[0] &= ~(1 << 29)
+        if payload_dws:
+            header_4dws[0] |= (1 << 30)
+        else:
+            header_4dws[0] &= ~(1 << 30)
+
         dut = _HeaderExtracterDUT(data_width=data_width)
 
         # Build PHY input beats (header + payload).
@@ -284,7 +316,9 @@ class TestLitePCIeTLPHeaderExtracter(unittest.TestCase):
         for i, (got, exp) in enumerate(zip(got_beats, exp_out_beats)):
             self.assertEqual(got["first"], exp["first"], msg=f"beat {i}: first mismatch")
             self.assertEqual(got["last"],  exp["last"],  msg=f"beat {i}: last mismatch")
-            self.assertEqual(got["dws"],   exp["dws"],   msg=f"beat {i}: dat mismatch")
+            # Ignore data when be is all zero.
+            if any(exp["be"]):
+                self.assertEqual(got["dws"],   exp["dws"],   msg=f"beat {i}: dat mismatch")
             self.assertEqual(got["be"],    exp["be"],    msg=f"beat {i}: be mismatch")
 
         # last must occur exactly once.
@@ -364,6 +398,9 @@ class TestLitePCIeTLPHeaderExtracter(unittest.TestCase):
 
     # Individual tests -----------------------------------------------------------------------------
 
+    def test_32b_basic(self):
+        self._basic_vectors(32)
+
     def test_64b_basic(self):
         self._basic_vectors(64)
 
@@ -375,6 +412,10 @@ class TestLitePCIeTLPHeaderExtracter(unittest.TestCase):
 
     def test_512b_basic(self):
         self._basic_vectors(512)
+
+    def test_32b_random(self):
+        random.seed(0x32)
+        self._random_vectors(32, ntests=80)
 
     def test_64b_random(self):
         random.seed(0x64)

--- a/test/test_header_inserter.py
+++ b/test/test_header_inserter.py
@@ -16,6 +16,7 @@ from litex.soc.interconnect import stream
 
 from litepcie.tlp.common import fmt_dict, tlp_raw_layout, phy_layout
 from litepcie.tlp.packetizer import (
+    LitePCIeTLPHeaderInserter32b,
     LitePCIeTLPHeaderInserter64b,
     LitePCIeTLPHeaderInserter128b,
     LitePCIeTLPHeaderInserter256b,
@@ -172,6 +173,7 @@ class _HeaderInserterDUT(LiteXModule):
         self.comb += fmt_sig.eq(self.sink.fmt)
 
         cls = {
+             32 : LitePCIeTLPHeaderInserter32b,
              64 : LitePCIeTLPHeaderInserter64b,
             128 : LitePCIeTLPHeaderInserter128b,
             256 : LitePCIeTLPHeaderInserter256b,
@@ -388,6 +390,9 @@ class TestLitePCIeTLPHeaderInserter(unittest.TestCase):
 
     # Individual tests -----------------------------------------------------------------------------
 
+    def test_32b_basic(self):
+        self._basic_vectors(32)
+
     def test_64b_basic(self):
         self._basic_vectors(64)
 
@@ -399,6 +404,10 @@ class TestLitePCIeTLPHeaderInserter(unittest.TestCase):
 
     def test_512b_basic(self):
         self._basic_vectors(512)
+
+    def test_32b_random(self):
+        random.seed(0x32)
+        self._random_vectors(32, ntests=80)
 
     def test_64b_random(self):
         random.seed(0x64)

--- a/test/test_wishbone.py
+++ b/test/test_wishbone.py
@@ -91,6 +91,9 @@ class TestWishboneMaster(unittest.TestCase):
         # Verify Write/Read datas match.
         self.assertEqual(wr_datas, rd_datas)
 
+    def test_wishbone_32b(self):
+        self.wishbone_test(data_width=32)
+
     def test_wishbone_64b(self):
         self.wishbone_test(data_width=64)
 
@@ -184,6 +187,9 @@ class TestWishboneSlave(unittest.TestCase):
         }
         clocks = {"sys": 10}
         run_simulation(dut, generators, clocks, vcd_name="sim.vcd")
+
+    def test_wishbone_32b(self):
+        self.wishbone_test(32)
 
     def test_wishbone_64b(self):
         self.wishbone_test(64)


### PR DESCRIPTION
I'm working on ECP5 support and I currently only support a 32-bit datapath through the lower layers since that's wide enough for a single lane Gen1/2 link.