### PR TITLE
tlp/controller: retire requests and free tags on error completions

### DIFF
--- a/litepcie/tlp/controller.py
+++ b/litepcie/tlp/controller.py
@@ -145,7 +145,11 @@ class LitePCIeTLPController(LiteXModule):
             {i: cmp_bufs[i].source.connect(cmp_source) for i in range(len(cmp_bufs))})
         self.comb += [
             # Pop Req from req_queue when Req is fully received.
-            If(cmp_source.valid & cmp_source.last & cmp_source.end,
+            # Retire on a normal end-of-completion OR on an error completion (UR/CA):
+            # an error Cpl is zero-length so "end" (length == byte_count) never asserts,
+            # which would otherwise leave the request un-retired and leak its tag,
+            # deadlocking the DMA reader.
+            If(cmp_source.valid & cmp_source.last & (cmp_source.end | cmp_source.err),
                 req_queue.source.ready.eq(cmp_source.ready)
             ),
             req_queue.source.connect(cmp_source, keep={"channel", "user_id"}),
@@ -184,7 +188,10 @@ class LitePCIeTLPController(LiteXModule):
             cmp_sink.connect(cmp_reorder, keep={"valid", "ready"}),
             # Push incoming Tag to tag_queue when Cmp is fully received.
             If(cmp_sink.valid & cmp_sink.ready & cmp_sink.last,
-                If(cmp_sink.end,
+                # Free the tag on a normal end-of-completion OR on an error completion
+                # (UR/CA): an error Cpl is zero-length (end stays 0), so without this the
+                # tag is never returned and the controller starves/deadlocks.
+                If(cmp_sink.end | cmp_sink.err,
                     tag_queue.sink.valid.eq(1),
                     tag_queue.sink.tag.eq(cmp_sink.tag)
                 ),


### PR DESCRIPTION
The TLP controller retired a read request and returned its tag to the tag queue only on a successful end-of-data completion (cmp.last & cmp.end).

An Unsupported-Request / Completer-Abort completion is a zero-length Cpl with a non-zero status, so "end" (length == byte_count[2:]) never asserts. The depacketizer already flags it via cmp.err, but the controller ignored that flag, so the outstanding request was never retired and its tag was never returned. With the default max_pending_requests=4 a short burst of failed reads exhausts the tag pool and the DMA reader deadlocks permanently.

This is reachable in practice: a TX (reader) read of a host address that the IOMMU rejects (stale/torn-down mapping after an abnormal host exit or driver remove) returns a UR/CA completion and hard-hangs the PCIe endpoint, which then drops off the bus / sticks in D3cold and needs a power cycle to recover.

Retire the request and free the tag on (end | err) so an error completion terminates the request instead of leaking the tag and stalling the engine.