### PR TITLE
frontend/dma: reset reader/writer data converters with the DMA

### DIFF
--- a/litepcie/frontend/dma.py
+++ b/litepcie/frontend/dma.py
@@ -319,7 +319,10 @@ class LitePCIeDMAReader(LiteXModule):
 
         # Data Converter ---------------------------------------------------------------------------
 
-        self.data_conv = stream.Converter(endpoint.phy.data_width, self.data_width)
+        # Reset with the DMA: a partial beat held across a disable would shift the next run's
+        # stream by a sub-beat word offset (visible as misaligned DMA headers on restart).
+        self.data_conv = ResetInserter()(stream.Converter(endpoint.phy.data_width, self.data_width))
+        self.comb += self.data_conv.reset.eq(~enable)
         self.comb += self.data_conv.source.connect(self.source)
 
         # Data FIFO --------------------------------------------------------------------------------
@@ -475,7 +478,10 @@ class LitePCIeDMAWriter(LiteXModule):
 
         # Data Converter ---------------------------------------------------------------------------
 
-        self.data_conv = stream.Converter(self.data_width, endpoint.phy.data_width)
+        # Reset with the DMA: a partial beat held across a disable would shift the next run's
+        # stream by a sub-beat word offset (visible as misaligned DMA headers on restart).
+        self.data_conv = ResetInserter()(stream.Converter(self.data_width, endpoint.phy.data_width))
+        self.comb += self.data_conv.reset.eq(~enable)
         self.comb += self.sink.connect(self.data_conv.sink)
 
         # Data FIFO --------------------------------------------------------------------------------


### PR DESCRIPTION
The DMA writer and reader reset their splitter and data FIFO when disabled, but not the data-width converters between the user stream and the FIFOs. An up-converter that stops while holding a partial beat (demux phase != 0) shifts the next run's entire stream by the held words; with sink.last then landing on an even word once, it additionally pads one garbage word into the byte stream before realigning. The down-converter on the reader side holds the equivalent state for TX.

On LiteX-M2SDR (64-bit DMA on a 128-bit PHY) this showed up as the per-buffer DMA headers landing 8 bytes (first buffer) then 16 bytes (steady state) into every 8 KiB host buffer after any writer stop/start cycle — deterministic across runs and driver reloads, since the converter state lives in the FPGA.

Fix: wrap both converters in a ResetInserter and reset them with ~enable, like the splitter and data FIFO already are. Verified on M2SDR hardware: header offset is 0 in every buffer across repeated stream restarts and full-duplex start/stop cycles (previously 8/16 bytes), with a loopback regression suite passing at 30.72–122.88 MSPS.