### PR TITLE
software: add NVIDIA GPUDirect DMA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,33 @@ enjoy-digital.fr.
 2. Install LiteX and the cores by following the LiteX's wiki [installation guide](https://github.com/enjoy-digital/litex/wiki/Installation).
 3. You can find examples of integration of the core with LiteX in LiteX-Boards and in the examples directory.
 
+[> NVIDIA GPUDirect RDMA
+------------------------
+The Linux driver can optionally map its DMA buffers directly in NVIDIA GPU
+memory. This requires a recent NVIDIA driver exposing the persistent P2P pages
+API and a platform topology supported by NVIDIA GPUDirect RDMA.
+
+Build the kernel module against the NVIDIA kernel headers:
+```sh
+$ cd litepcie/software/kernel
+$ make NV_DMA=true NVIDIA_PATH=/usr/src/nvidia-<version>/nvidia
+```
+
+Build the utility against the CUDA driver API and run the DMA counter test on
+GPU 0:
+```sh
+$ cd litepcie/software/user
+$ make NV_DMA=true CUDA_PATH=/usr/local/cuda
+$ sudo ./litepcie_util -g 0 dma_test
+```
+
+Load the NVIDIA kernel module before `litepcie.ko`. The GPU allocation is
+64KiB-aligned by the utility and is mapped per open LitePCIe DMA channel. The
+normal CPU-backed DMA path remains the default.
+
+This support is based on the initial GPUDirect implementation proposed by
+Steve Kelly, Tim Besard and Elliot Saba in [PR #107](https://github.com/enjoy-digital/litepcie/pull/107).
+
 [> Tests
 --------
 Unit tests are available in ./test/.

--- a/litepcie/software/kernel/Makefile
+++ b/litepcie/software/kernel/Makefile
@@ -3,21 +3,29 @@ KERNEL_VERSION:=$(shell uname -r)
 KERNEL_PATH?=/lib/modules/$(KERNEL_VERSION)/build
 ARCH?=$(shell uname -m)
 
+NV_DMA?=false
+NVIDIA_PATH?=/usr/src/nvidia
+KBUILD_OPTIONS=
+
 obj-m = litepcie.o liteuart.o
 litepcie-objs = main.o
 #liteuart-objs = liteuart.o
 
+ifeq ($(NV_DMA),true)
+ifeq ($(wildcard $(NVIDIA_PATH)/nv-p2p.h),)
+$(error nv-p2p.h not found in NVIDIA_PATH=$(NVIDIA_PATH))
+endif
+ccflags-y += -I$(NVIDIA_PATH) -DLITEPCIE_NVIDIA_P2P
+# NVIDIA's exported symbols are resolved when its kernel module is loaded.
+KBUILD_OPTIONS += KBUILD_MODPOST_WARN=1
+endif
 
-all: litepcie.ko liteuart.ko
+.PHONY: all clean
 
-litepcie.ko: main.c
-	make -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) modules
-
-litepcie.ko: litepcie.h config.h flags.h csr.h soc.h
-
-liteuart.ko: liteuart.c
-	make -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) modules
+all: main.c liteuart.c litepcie.h config.h flags.h csr.h soc.h
+	+$(MAKE) -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) \
+		M=$(shell pwd) $(KBUILD_OPTIONS) modules
 
 clean:
-	make -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) clean
+	+$(MAKE) -C $(KERNEL_PATH) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) clean
 	rm -f *~

--- a/litepcie/software/kernel/litepcie.h
+++ b/litepcie/software/kernel/litepcie.h
@@ -33,6 +33,11 @@ struct litepcie_ioctl_icap {
 	uint32_t data;
 };
 
+struct litepcie_ioctl_dma_map_gpu {
+	uint64_t gpu_addr;
+	uint64_t gpu_size;
+};
+
 struct litepcie_ioctl_dma {
 	uint8_t loopback_enable;
 };
@@ -78,9 +83,11 @@ struct litepcie_ioctl_mmap_dma_update {
 #define LITEPCIE_IOCTL_FLASH             _IOWR(LITEPCIE_IOCTL,  1, struct litepcie_ioctl_flash)
 #define LITEPCIE_IOCTL_ICAP              _IOWR(LITEPCIE_IOCTL,  2, struct litepcie_ioctl_icap)
 
+#define LITEPCIE_IOCTL_DMA_MAP_GPU               _IOW(LITEPCIE_IOCTL,  19, struct litepcie_ioctl_dma_map_gpu)
 #define LITEPCIE_IOCTL_DMA                       _IOW(LITEPCIE_IOCTL,  20, struct litepcie_ioctl_dma)
 #define LITEPCIE_IOCTL_DMA_WRITER                _IOWR(LITEPCIE_IOCTL, 21, struct litepcie_ioctl_dma_writer)
 #define LITEPCIE_IOCTL_DMA_READER                _IOWR(LITEPCIE_IOCTL, 22, struct litepcie_ioctl_dma_reader)
+#define LITEPCIE_IOCTL_DMA_UNMAP_GPU             _IO(LITEPCIE_IOCTL,  23)
 #define LITEPCIE_IOCTL_MMAP_DMA_INFO             _IOR(LITEPCIE_IOCTL,  24, struct litepcie_ioctl_mmap_dma_info)
 #define LITEPCIE_IOCTL_LOCK                      _IOWR(LITEPCIE_IOCTL, 25, struct litepcie_ioctl_lock)
 #define LITEPCIE_IOCTL_MMAP_DMA_WRITER_UPDATE    _IOW(LITEPCIE_IOCTL,  26, struct litepcie_ioctl_mmap_dma_update)

--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -45,6 +45,10 @@
 #include "flags.h"
 #include "soc.h"
 
+#ifdef LITEPCIE_NVIDIA_P2P
+#include "nv-p2p.h"
+#endif
+
 //#define DEBUG_CSR
 //#define DEBUG_MSI
 //#define DEBUG_POLL
@@ -105,10 +109,28 @@ struct litepcie_device {
 	int channels;                                 /* Number of DMA channels */
 };
 
+#ifdef LITEPCIE_NVIDIA_P2P
+#define NVIDIA_GPU_PAGE_SHIFT 16
+#define NVIDIA_GPU_PAGE_SIZE  (1ULL << NVIDIA_GPU_PAGE_SHIFT)
+
+struct litepcie_gpu_mapping {
+	uint64_t virtual_address;
+	uint64_t mapped_size;
+	nvidia_p2p_page_table_t *page_table;
+	nvidia_p2p_dma_mapping_t *dma_mapping;
+	dma_addr_t reader_handle[DMA_BUFFER_COUNT];
+	dma_addr_t writer_handle[DMA_BUFFER_COUNT];
+};
+#endif
+
 struct litepcie_chan_priv {
 	struct litepcie_chan *chan;
 	bool reader;
 	bool writer;
+#ifdef LITEPCIE_NVIDIA_P2P
+	struct litepcie_gpu_mapping *gpu_mapping;
+	struct mutex gpu_lock;
+#endif
 };
 
 static int litepcie_major;
@@ -205,7 +227,168 @@ static int litepcie_dma_init(struct litepcie_device *s)
 	return 0;
 }
 
-static void litepcie_dma_writer_start(struct litepcie_device *s, int chan_num)
+#ifdef LITEPCIE_NVIDIA_P2P
+
+#ifndef NVIDIA_P2P_CAP_GET_PAGES_PERSISTENT_API
+#error "LitePCIe NVIDIA P2P support requires the persistent pages API"
+#endif
+
+static uint64_t litepcie_gpu_page_size(enum nvidia_p2p_page_size_type page_size_type)
+{
+	switch (page_size_type) {
+	case NVIDIA_P2P_PAGE_SIZE_4KB:
+		return 4 * 1024;
+	case NVIDIA_P2P_PAGE_SIZE_64KB:
+		return 64 * 1024;
+	case NVIDIA_P2P_PAGE_SIZE_128KB:
+		return 128 * 1024;
+	default:
+		return 0;
+	}
+}
+
+static int litepcie_gpu_dma_address(struct litepcie_gpu_mapping *mapping,
+	uint64_t offset, dma_addr_t *address)
+{
+	uint64_t page_size;
+	uint64_t page_offset;
+	uint64_t page;
+
+	page_size = litepcie_gpu_page_size(mapping->dma_mapping->page_size_type);
+	if (!page_size || DMA_BUFFER_SIZE > page_size)
+		return -EINVAL;
+
+	page = div64_u64_rem(offset, page_size, &page_offset);
+	if (page >= mapping->dma_mapping->entries ||
+	    page_offset + DMA_BUFFER_SIZE > page_size)
+		return -EINVAL;
+
+	*address = mapping->dma_mapping->dma_addresses[page] + page_offset;
+	return 0;
+}
+
+static int litepcie_dma_map_gpu(struct litepcie_chan_priv *chan_priv,
+	uint64_t gpu_addr, uint64_t gpu_size)
+{
+	struct litepcie_device *s = chan_priv->chan->litepcie_dev;
+	struct litepcie_gpu_mapping *mapping;
+	uint64_t required_size = 2ULL * DMA_BUFFER_TOTAL_SIZE;
+	uint64_t mapped_size = ALIGN(required_size, NVIDIA_GPU_PAGE_SIZE);
+	uint64_t page_size;
+	int i;
+	int ret;
+
+	if (chan_priv->gpu_mapping)
+		return -EBUSY;
+	if (!chan_priv->reader && !chan_priv->writer)
+		return -EACCES;
+	if ((chan_priv->reader && chan_priv->chan->dma.reader_enable) ||
+	    (chan_priv->writer && chan_priv->chan->dma.writer_enable))
+		return -EBUSY;
+	if ((gpu_addr & (NVIDIA_GPU_PAGE_SIZE - 1)) || gpu_size < mapped_size)
+		return -EINVAL;
+
+	mapping = kzalloc(sizeof(*mapping), GFP_KERNEL);
+	if (!mapping)
+		return -ENOMEM;
+	mapping->virtual_address = gpu_addr;
+	mapping->mapped_size = mapped_size;
+
+	ret = nvidia_p2p_get_pages_persistent(
+		mapping->virtual_address,
+		mapping->mapped_size,
+		&mapping->page_table,
+		NVIDIA_P2P_FLAGS_DEFAULT);
+	if (ret) {
+		dev_err(&s->dev->dev, "Failed to pin NVIDIA GPU pages: %d\n", ret);
+		goto fail_free;
+	}
+
+	if (!NVIDIA_P2P_PAGE_TABLE_VERSION_COMPATIBLE(mapping->page_table)) {
+		dev_err(&s->dev->dev, "Incompatible NVIDIA page table version: 0x%08x\n",
+			mapping->page_table->version);
+		ret = -EINVAL;
+		goto fail_put_pages;
+	}
+
+	ret = nvidia_p2p_dma_map_pages(s->dev, mapping->page_table,
+		&mapping->dma_mapping);
+	if (ret) {
+		dev_err(&s->dev->dev, "Failed to map NVIDIA GPU pages: %d\n", ret);
+		goto fail_put_pages;
+	}
+
+	page_size = litepcie_gpu_page_size(mapping->dma_mapping->page_size_type);
+	if (!NVIDIA_P2P_DMA_MAPPING_VERSION_COMPATIBLE(mapping->dma_mapping) ||
+	    !page_size || mapping->dma_mapping->entries <
+	    DIV_ROUND_UP_ULL(mapping->mapped_size, page_size)) {
+		dev_err(&s->dev->dev, "Incompatible NVIDIA DMA mapping\n");
+		ret = -EINVAL;
+		goto fail_unmap_pages;
+	}
+
+	for (i = 0; i < DMA_BUFFER_COUNT; i++) {
+		ret = litepcie_gpu_dma_address(mapping,
+			i * DMA_BUFFER_SIZE,
+			&mapping->reader_handle[i]);
+		if (ret)
+			goto fail_invalid_layout;
+
+		ret = litepcie_gpu_dma_address(mapping,
+			DMA_BUFFER_TOTAL_SIZE + i * DMA_BUFFER_SIZE,
+			&mapping->writer_handle[i]);
+		if (ret)
+			goto fail_invalid_layout;
+	}
+
+	chan_priv->gpu_mapping = mapping;
+	return 0;
+
+fail_invalid_layout:
+	dev_err(&s->dev->dev,
+		"NVIDIA GPU page layout cannot provide contiguous DMA buffers\n");
+fail_unmap_pages:
+	nvidia_p2p_dma_unmap_pages(s->dev, mapping->page_table,
+		mapping->dma_mapping);
+fail_put_pages:
+	nvidia_p2p_put_pages_persistent(mapping->virtual_address,
+		mapping->page_table, NVIDIA_P2P_FLAGS_DEFAULT);
+fail_free:
+	kfree(mapping);
+	return ret;
+}
+
+static int litepcie_dma_unmap_gpu(struct litepcie_chan_priv *chan_priv)
+{
+	struct litepcie_device *s = chan_priv->chan->litepcie_dev;
+	struct litepcie_gpu_mapping *mapping = chan_priv->gpu_mapping;
+	int put_ret;
+	int ret;
+
+	if (!mapping)
+		return -EINVAL;
+	if ((chan_priv->reader && chan_priv->chan->dma.reader_enable) ||
+	    (chan_priv->writer && chan_priv->chan->dma.writer_enable))
+		return -EBUSY;
+
+	ret = nvidia_p2p_dma_unmap_pages(s->dev, mapping->page_table,
+		mapping->dma_mapping);
+	put_ret = nvidia_p2p_put_pages_persistent(mapping->virtual_address,
+		mapping->page_table, NVIDIA_P2P_FLAGS_DEFAULT);
+	if (!ret)
+		ret = put_ret;
+	if (ret)
+		dev_err(&s->dev->dev, "Failed to release NVIDIA GPU mapping: %d\n", ret);
+
+	chan_priv->gpu_mapping = NULL;
+	kfree(mapping);
+	return ret;
+}
+
+#endif
+
+static void litepcie_dma_writer_start(struct litepcie_device *s, int chan_num,
+	const dma_addr_t *handles)
 {
 	struct litepcie_dma_chan *dmachan;
 	int i;
@@ -225,9 +408,9 @@ static void litepcie_dma_writer_start(struct litepcie_device *s, int chan_num)
 			(!(i%DMA_BUFFER_PER_IRQ == 0)) * DMA_IRQ_DISABLE | /* generate an msi */
 			DMA_BUFFER_SIZE);                                  /* every n buffers */
 		/* Fill 32-bit Address LSB. */
-		litepcie_writel(s, dmachan->base + PCIE_DMA_WRITER_TABLE_VALUE_OFFSET + 4, (dmachan->writer_handle[i] >>  0) & 0xffffffff);
+		litepcie_writel(s, dmachan->base + PCIE_DMA_WRITER_TABLE_VALUE_OFFSET + 4, (handles[i] >>  0) & 0xffffffff);
 		/* Write descriptor (and fill 32-bit Address MSB for 64-bit mode). */
-		litepcie_writel(s, dmachan->base + PCIE_DMA_WRITER_TABLE_WE_OFFSET,        (dmachan->writer_handle[i] >> 32) & 0xffffffff);
+		litepcie_writel(s, dmachan->base + PCIE_DMA_WRITER_TABLE_WE_OFFSET,        (handles[i] >> 32) & 0xffffffff);
 	}
 	litepcie_writel(s, dmachan->base + PCIE_DMA_WRITER_TABLE_LOOP_PROG_N_OFFSET, 1);
 
@@ -259,7 +442,8 @@ static void litepcie_dma_writer_stop(struct litepcie_device *s, int chan_num)
 	dmachan->writer_sw_count = 0;
 }
 
-static void litepcie_dma_reader_start(struct litepcie_device *s, int chan_num)
+static void litepcie_dma_reader_start(struct litepcie_device *s, int chan_num,
+	const dma_addr_t *handles)
 {
 	struct litepcie_dma_chan *dmachan;
 	int i;
@@ -279,9 +463,9 @@ static void litepcie_dma_reader_start(struct litepcie_device *s, int chan_num)
 			(!(i%DMA_BUFFER_PER_IRQ == 0)) * DMA_IRQ_DISABLE | /* generate an msi */
 			DMA_BUFFER_SIZE);                                  /* every n buffers */
 		/* Fill 32-bit Address LSB. */
-		litepcie_writel(s, dmachan->base + PCIE_DMA_READER_TABLE_VALUE_OFFSET + 4, (dmachan->reader_handle[i] >>  0) & 0xffffffff);
+		litepcie_writel(s, dmachan->base + PCIE_DMA_READER_TABLE_VALUE_OFFSET + 4, (handles[i] >>  0) & 0xffffffff);
 		/* Write descriptor (and fill 32-bit Address MSB for 64-bit mode). */
-		litepcie_writel(s, dmachan->base + PCIE_DMA_READER_TABLE_WE_OFFSET, (dmachan->reader_handle[i] >> 32) & 0xffffffff);
+		litepcie_writel(s, dmachan->base + PCIE_DMA_READER_TABLE_WE_OFFSET, (handles[i] >> 32) & 0xffffffff);
 	}
 	litepcie_writel(s, dmachan->base + PCIE_DMA_READER_TABLE_LOOP_PROG_N_OFFSET, 1);
 
@@ -407,6 +591,9 @@ static int litepcie_open(struct inode *inode, struct file *file)
 		return -ENOMEM;
 
 	chan_priv->chan = chan;
+#ifdef LITEPCIE_NVIDIA_P2P
+	mutex_init(&chan_priv->gpu_lock);
+#endif
 	file->private_data = chan_priv;
 
 	if (chan->dma.reader_enable == 0) { /* clear only if disabled */
@@ -447,6 +634,11 @@ static int litepcie_release(struct inode *inode, struct file *file)
 		chan->dma.writer_enable = 0;
 	}
 
+#ifdef LITEPCIE_NVIDIA_P2P
+	if (chan_priv->gpu_mapping)
+		litepcie_dma_unmap_gpu(chan_priv);
+#endif
+
 	kfree(chan_priv);
 
 	return 0;
@@ -461,6 +653,11 @@ static ssize_t litepcie_read(struct file *file, char __user *data, size_t size, 
 	struct litepcie_chan_priv *chan_priv = file->private_data;
 	struct litepcie_chan *chan = chan_priv->chan;
 	struct litepcie_device *s = chan->litepcie_dev;
+
+#ifdef LITEPCIE_NVIDIA_P2P
+	if (chan_priv->gpu_mapping)
+		return -EOPNOTSUPP;
+#endif
 
 	if (file->f_flags & O_NONBLOCK) {
 		if (chan->dma.writer_hw_count == chan->dma.writer_sw_count)
@@ -517,6 +714,11 @@ static ssize_t litepcie_write(struct file *file, const char __user *data, size_t
 	struct litepcie_chan *chan = chan_priv->chan;
 	struct litepcie_device *s = chan->litepcie_dev;
 
+#ifdef LITEPCIE_NVIDIA_P2P
+	if (chan_priv->gpu_mapping)
+		return -EOPNOTSUPP;
+#endif
+
 	if (file->f_flags & O_NONBLOCK) {
 		if (chan->dma.reader_hw_count == chan->dma.reader_sw_count)
 			ret = -EAGAIN;
@@ -572,6 +774,11 @@ static int litepcie_mmap(struct file *file, struct vm_area_struct *vma)
 	int ret;
 #endif
 	int is_tx, i;
+
+#ifdef LITEPCIE_NVIDIA_P2P
+	if (chan_priv->gpu_mapping)
+		return -EOPNOTSUPP;
+#endif
 
 	if (vma->vm_end - vma->vm_start != DMA_BUFFER_TOTAL_SIZE)
 		return -EINVAL;
@@ -751,6 +958,26 @@ static long litepcie_ioctl(struct file *file, unsigned int cmd,
 	}
 	break;
 #endif
+#ifdef LITEPCIE_NVIDIA_P2P
+	case LITEPCIE_IOCTL_DMA_MAP_GPU:
+	{
+		struct litepcie_ioctl_dma_map_gpu m;
+
+		if (copy_from_user(&m, (void *)arg, sizeof(m))) {
+			ret = -EFAULT;
+			break;
+		}
+		mutex_lock(&chan_priv->gpu_lock);
+		ret = litepcie_dma_map_gpu(chan_priv, m.gpu_addr, m.gpu_size);
+		mutex_unlock(&chan_priv->gpu_lock);
+	}
+	break;
+	case LITEPCIE_IOCTL_DMA_UNMAP_GPU:
+		mutex_lock(&chan_priv->gpu_lock);
+		ret = litepcie_dma_unmap_gpu(chan_priv);
+		mutex_unlock(&chan_priv->gpu_lock);
+		break;
+#endif
 	case LITEPCIE_IOCTL_DMA:
 	{
 		struct litepcie_ioctl_dma m;
@@ -767,16 +994,30 @@ static long litepcie_ioctl(struct file *file, unsigned int cmd,
 	case LITEPCIE_IOCTL_DMA_WRITER:
 	{
 		struct litepcie_ioctl_dma_writer m;
+		const dma_addr_t *handles = chan->dma.writer_handle;
 
 		if (copy_from_user(&m, (void *)arg, sizeof(m))) {
 			ret = -EFAULT;
 			break;
 		}
 
+#ifdef LITEPCIE_NVIDIA_P2P
+		mutex_lock(&chan_priv->gpu_lock);
+		if (chan_priv->gpu_mapping) {
+			if (m.enable && !chan_priv->writer) {
+				mutex_unlock(&chan_priv->gpu_lock);
+				ret = -EACCES;
+				break;
+			}
+			handles = chan_priv->gpu_mapping->writer_handle;
+		}
+#endif
+
 		if (m.enable != chan->dma.writer_enable) {
 			/* enable / disable DMA */
 			if (m.enable) {
-				litepcie_dma_writer_start(chan->litepcie_dev, chan->index);
+				litepcie_dma_writer_start(chan->litepcie_dev, chan->index,
+					handles);
 				litepcie_enable_interrupt(chan->litepcie_dev, chan->dma.writer_interrupt);
 			} else {
 				litepcie_disable_interrupt(chan->litepcie_dev, chan->dma.writer_interrupt);
@@ -790,6 +1031,10 @@ static long litepcie_ioctl(struct file *file, unsigned int cmd,
 		m.hw_count = chan->dma.writer_hw_count;
 		m.sw_count = chan->dma.writer_sw_count;
 
+#ifdef LITEPCIE_NVIDIA_P2P
+		mutex_unlock(&chan_priv->gpu_lock);
+#endif
+
 		if (copy_to_user((void *)arg, &m, sizeof(m))) {
 			ret = -EFAULT;
 			break;
@@ -800,16 +1045,30 @@ static long litepcie_ioctl(struct file *file, unsigned int cmd,
 	case LITEPCIE_IOCTL_DMA_READER:
 	{
 		struct litepcie_ioctl_dma_reader m;
+		const dma_addr_t *handles = chan->dma.reader_handle;
 
 		if (copy_from_user(&m, (void *)arg, sizeof(m))) {
 			ret = -EFAULT;
 			break;
 		}
 
+#ifdef LITEPCIE_NVIDIA_P2P
+		mutex_lock(&chan_priv->gpu_lock);
+		if (chan_priv->gpu_mapping) {
+			if (m.enable && !chan_priv->reader) {
+				mutex_unlock(&chan_priv->gpu_lock);
+				ret = -EACCES;
+				break;
+			}
+			handles = chan_priv->gpu_mapping->reader_handle;
+		}
+#endif
+
 		if (m.enable != chan->dma.reader_enable) {
 			/* enable / disable DMA */
 			if (m.enable) {
-				litepcie_dma_reader_start(chan->litepcie_dev, chan->index);
+				litepcie_dma_reader_start(chan->litepcie_dev, chan->index,
+					handles);
 				litepcie_enable_interrupt(chan->litepcie_dev, chan->dma.reader_interrupt);
 			} else {
 				litepcie_disable_interrupt(chan->litepcie_dev, chan->dma.reader_interrupt);
@@ -821,6 +1080,10 @@ static long litepcie_ioctl(struct file *file, unsigned int cmd,
 
 		m.hw_count = chan->dma.reader_hw_count;
 		m.sw_count = chan->dma.reader_sw_count;
+
+#ifdef LITEPCIE_NVIDIA_P2P
+		mutex_unlock(&chan_priv->gpu_lock);
+#endif
 
 		if (copy_to_user((void *)arg, &m, sizeof(m))) {
 			ret = -EFAULT;

--- a/litepcie/software/user/Makefile
+++ b/litepcie/software/user/Makefile
@@ -3,6 +3,18 @@ LDFLAGS=-g
 CC=$(CROSS_COMPILE)gcc
 AR=ar
 
+NV_DMA?=false
+CUDA_PATH?=/usr/local/cuda
+
+ifeq ($(NV_DMA),true)
+ifeq ($(wildcard $(CUDA_PATH)/include/cuda.h),)
+$(error cuda.h not found in CUDA_PATH=$(CUDA_PATH))
+endif
+CFLAGS += -I$(CUDA_PATH)/include -DLITEPCIE_NVIDIA_P2P
+LDFLAGS += -L$(CUDA_PATH)/lib64 -L$(CUDA_PATH)/lib
+NV_LDLIBS += -lcuda
+endif
+
 PROGS=litepcie_util litepcie_test
 
 all: $(PROGS)
@@ -11,11 +23,11 @@ liblitepcie/liblitepcie.a: liblitepcie/litepcie_dma.o liblitepcie/litepcie_flash
 	ar rcs $@ $+
 	ranlib $@
 
-litepcie_util: liblitepcie/liblitepcie.a litepcie_util.o
-	$(CC) $(LDFLAGS) -o $@ $^ -Lliblitepcie -llitepcie
+litepcie_util: litepcie_util.o liblitepcie/liblitepcie.a
+	$(CC) $(LDFLAGS) -o $@ $^ $(NV_LDLIBS)
 
-litepcie_test: liblitepcie/liblitepcie.a litepcie_test.o
-	$(CC) $(LDFLAGS) -o $@ $^ -Lliblitepcie -lm -llitepcie
+litepcie_test: litepcie_test.o liblitepcie/liblitepcie.a
+	$(CC) $(LDFLAGS) -o $@ $^ -lm
 
 clean:
 	rm -f $(PROGS) *.o *.a *.d *~ liblitepcie/*.a liblitepcie/*.o liblitepcie/*.d

--- a/litepcie/software/user/liblitepcie/litepcie_dma.c
+++ b/litepcie/software/user/liblitepcie/litepcie_dma.c
@@ -43,12 +43,19 @@ void litepcie_dma_reader(int fd, uint8_t enable, int64_t *hw_count, int64_t *sw_
 
 uint8_t litepcie_request_dma(int fd, uint8_t reader, uint8_t writer) {
     struct litepcie_ioctl_lock m;
+    uint8_t status;
+
     m.dma_reader_request = reader > 0;
     m.dma_writer_request = writer > 0;
     m.dma_reader_release = 0;
     m.dma_writer_release = 0;
     checked_ioctl(fd, LITEPCIE_IOCTL_LOCK, &m);
-    return m.dma_reader_status;
+    status = (!reader || m.dma_reader_status) && (!writer || m.dma_writer_status);
+    if (!status)
+        litepcie_release_dma(fd,
+            reader && m.dma_reader_status,
+            writer && m.dma_writer_status);
+    return status;
 }
 
 void litepcie_release_dma(int fd, uint8_t reader, uint8_t writer) {
@@ -60,14 +67,29 @@ void litepcie_release_dma(int fd, uint8_t reader, uint8_t writer) {
     checked_ioctl(fd, LITEPCIE_IOCTL_LOCK, &m);
 }
 
-int litepcie_dma_init(struct litepcie_dma_ctrl *dma, const char *device_name, uint8_t zero_copy)
+int litepcie_dma_map_gpu(int fd, uint64_t gpu_addr, uint64_t gpu_size) {
+    struct litepcie_ioctl_dma_map_gpu m = {
+        .gpu_addr = gpu_addr,
+        .gpu_size = gpu_size,
+    };
+    return ioctl(fd, LITEPCIE_IOCTL_DMA_MAP_GPU, &m);
+}
+
+int litepcie_dma_unmap_gpu(int fd) {
+    return ioctl(fd, LITEPCIE_IOCTL_DMA_UNMAP_GPU);
+}
+
+static int litepcie_dma_init_common(struct litepcie_dma_ctrl *dma,
+    const char *device_name, uint8_t zero_copy, uint64_t gpu_addr, uint64_t gpu_size)
 {
     dma->reader_hw_count = 0;
     dma->reader_sw_count = 0;
     dma->writer_hw_count = 0;
     dma->writer_sw_count = 0;
 
-    dma->zero_copy = zero_copy;
+    dma->gpu = gpu_size != 0;
+    dma->zero_copy = zero_copy || dma->gpu;
+    dma->fds.events = 0;
 
     if (dma->use_reader)
         dma->fds.events |= POLLOUT;
@@ -84,12 +106,24 @@ int litepcie_dma_init(struct litepcie_dma_ctrl *dma, const char *device_name, ui
     /* request dma reader and writer */
     if ((litepcie_request_dma(dma->fds.fd, dma->use_reader, dma->use_writer) == 0)) {
         fprintf(stderr, "DMA not available\n");
+        if (dma->shared_fd != 1)
+            close(dma->fds.fd);
         return -1;
     }
 
     litepcie_dma_set_loopback(dma->fds.fd, dma->loopback);
 
-    if (dma->zero_copy) {
+    if (dma->gpu) {
+        if (litepcie_dma_map_gpu(dma->fds.fd, gpu_addr, gpu_size) < 0) {
+            perror("Could not map NVIDIA GPU memory");
+            litepcie_release_dma(dma->fds.fd, dma->use_reader, dma->use_writer);
+            if (dma->shared_fd != 1)
+                close(dma->fds.fd);
+            return -1;
+        }
+        dma->buf_wr = (char *)(uintptr_t)gpu_addr;
+        dma->buf_rd = dma->buf_wr + DMA_BUFFER_TOTAL_SIZE;
+    } else if (dma->zero_copy) {
         /* if mmap: get it from the kernel */
         checked_ioctl(dma->fds.fd, LITEPCIE_IOCTL_MMAP_DMA_INFO, &dma->mmap_dma_info);
         if (dma->use_writer) {
@@ -130,6 +164,17 @@ int litepcie_dma_init(struct litepcie_dma_ctrl *dma, const char *device_name, ui
     return 0;
 }
 
+int litepcie_dma_init(struct litepcie_dma_ctrl *dma, const char *device_name, uint8_t zero_copy)
+{
+    return litepcie_dma_init_common(dma, device_name, zero_copy, 0, 0);
+}
+
+int litepcie_dma_init_gpu(struct litepcie_dma_ctrl *dma, const char *device_name,
+    uint64_t gpu_addr, uint64_t gpu_size)
+{
+    return litepcie_dma_init_common(dma, device_name, 1, gpu_addr, gpu_size);
+}
+
 void litepcie_dma_cleanup(struct litepcie_dma_ctrl *dma)
 {
     if (dma->use_reader)
@@ -137,9 +182,12 @@ void litepcie_dma_cleanup(struct litepcie_dma_ctrl *dma)
     if (dma->use_writer)
         litepcie_dma_writer(dma->fds.fd, 0, &dma->writer_hw_count, &dma->writer_sw_count);
 
-    litepcie_release_dma(dma->fds.fd, dma->use_reader, dma->use_writer);
-
-    if (dma->zero_copy) {
+    if (dma->gpu) {
+        if (litepcie_dma_unmap_gpu(dma->fds.fd) < 0)
+            perror("Could not unmap NVIDIA GPU memory");
+        dma->buf_wr = NULL;
+        dma->buf_rd = NULL;
+    } else if (dma->zero_copy) {
         if (dma->use_reader) {
             munmap(dma->buf_wr, dma->mmap_dma_info.dma_tx_buf_size * dma->mmap_dma_info.dma_tx_buf_count);
             dma->buf_wr = NULL;
@@ -158,6 +206,8 @@ void litepcie_dma_cleanup(struct litepcie_dma_ctrl *dma)
             dma->buf_rd = NULL;
         }
     }
+
+    litepcie_release_dma(dma->fds.fd, dma->use_reader, dma->use_writer);
 
     if (dma->shared_fd != 1)
         close(dma->fds.fd);

--- a/litepcie/software/user/liblitepcie/litepcie_dma.h
+++ b/litepcie/software/user/liblitepcie/litepcie_dma.h
@@ -16,7 +16,7 @@
 #include "litepcie.h"
 
 struct litepcie_dma_ctrl {
-    uint8_t use_reader, use_writer, loopback, zero_copy, shared_fd;
+    uint8_t use_reader, use_writer, loopback, zero_copy, shared_fd, gpu;
     struct pollfd fds;
     char *buf_rd, *buf_wr;
     uint8_t reader_enable;
@@ -35,8 +35,17 @@ void litepcie_dma_writer(int fd, uint8_t enable, int64_t *hw_count, int64_t *sw_
 
 uint8_t litepcie_request_dma(int fd, uint8_t reader, uint8_t writer);
 void litepcie_release_dma(int fd, uint8_t reader, uint8_t writer);
+int litepcie_dma_map_gpu(int fd, uint64_t gpu_addr, uint64_t gpu_size);
+int litepcie_dma_unmap_gpu(int fd);
 
 int litepcie_dma_init(struct litepcie_dma_ctrl *dma, const char *device_name, uint8_t zero_copy);
+/*
+ * The GPU region contains the DMA reader source followed by the DMA writer
+ * destination. These are CUDA device pointers and must not be dereferenced by
+ * the CPU. The caller must enable CU_POINTER_ATTRIBUTE_SYNC_MEMOPS first.
+ */
+int litepcie_dma_init_gpu(struct litepcie_dma_ctrl *dma, const char *device_name,
+    uint64_t gpu_addr, uint64_t gpu_size);
 void litepcie_dma_cleanup(struct litepcie_dma_ctrl *dma);
 void litepcie_dma_process(struct litepcie_dma_ctrl *dma);
 char *litepcie_dma_next_read_buffer(struct litepcie_dma_ctrl *dma);

--- a/litepcie/software/user/litepcie_util.c
+++ b/litepcie/software/user/litepcie_util.c
@@ -16,6 +16,9 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <signal.h>
+#ifdef LITEPCIE_NVIDIA_P2P
+#include <cuda.h>
+#endif
 #include "liblitepcie.h"
 
 /* Parameters */
@@ -35,6 +38,26 @@ sig_atomic_t keep_running = 1;
 void intHandler(int dummy) {
     keep_running = 0;
 }
+
+#ifdef LITEPCIE_NVIDIA_P2P
+
+#define NVIDIA_GPU_PAGE_SIZE (64 * 1024)
+
+static void cuda_check(CUresult result, const char *operation)
+{
+    const char *error_name = "unknown";
+    const char *error_string = "unknown error";
+
+    if (result == CUDA_SUCCESS)
+        return;
+
+    cuGetErrorName(result, &error_name);
+    cuGetErrorString(result, &error_string);
+    fprintf(stderr, "%s failed: %s (%s)\n", operation, error_name, error_string);
+    exit(1);
+}
+
+#endif
 
 /* Info */
 /*------*/
@@ -343,9 +366,19 @@ static int check_pn_data(const uint32_t *buf, int count, uint32_t *pseed, int da
 }
 #endif
 
-static void dma_test(uint8_t zero_copy, uint8_t external_loopback, int data_width, int auto_rx_delay, int duration)
+static void dma_test(uint8_t zero_copy, uint8_t external_loopback, int data_width,
+    int auto_rx_delay, int duration, int gpu_device)
 {
     static struct litepcie_dma_ctrl dma = {.use_reader = 1, .use_writer = 1};
+    int gpu_mode = gpu_device >= 0;
+#ifdef LITEPCIE_NVIDIA_P2P
+    CUcontext gpu_context;
+    CUdeviceptr gpu_allocation;
+    CUdeviceptr gpu_buffer;
+    size_t gpu_buffer_size = (2 * DMA_BUFFER_TOTAL_SIZE + NVIDIA_GPU_PAGE_SIZE - 1) &
+        ~(NVIDIA_GPU_PAGE_SIZE - 1);
+    unsigned int sync_memops = 1;
+#endif
     dma.loopback = external_loopback ? 0 : 1;
 
     if (data_width > 32 || data_width < 1) {
@@ -363,7 +396,7 @@ static void dma_test(uint8_t zero_copy, uint8_t external_loopback, int data_widt
 #ifdef DMA_CHECK_DATA
     uint32_t seed_wr = 0;
     uint32_t seed_rd = 0;
-    uint8_t  run = (auto_rx_delay == 0);
+    uint8_t  run = gpu_mode || (auto_rx_delay == 0);
 #else
     uint8_t run = 1;
 #endif
@@ -373,8 +406,31 @@ static void dma_test(uint8_t zero_copy, uint8_t external_loopback, int data_widt
     printf("\e[1m[> DMA loopback test:\e[0m\n");
     printf("---------------------\n");
 
-    if (litepcie_dma_init(&dma, litepcie_device, zero_copy))
+#ifdef LITEPCIE_NVIDIA_P2P
+    if (gpu_mode) {
+        CUdevice device;
+
+        cuda_check(cuInit(0), "cuInit");
+        cuda_check(cuDeviceGet(&device, gpu_device), "cuDeviceGet");
+        cuda_check(cuCtxCreate(&gpu_context, 0, device), "cuCtxCreate");
+        cuda_check(cuMemAlloc(&gpu_allocation,
+            gpu_buffer_size + NVIDIA_GPU_PAGE_SIZE - 1), "cuMemAlloc");
+        gpu_buffer = (gpu_allocation + NVIDIA_GPU_PAGE_SIZE - 1) &
+            ~(CUdeviceptr)(NVIDIA_GPU_PAGE_SIZE - 1);
+        cuda_check(cuPointerSetAttribute(&sync_memops,
+            CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, gpu_buffer), "cuPointerSetAttribute");
+        cuda_check(cuMemsetD8(gpu_buffer, 0, gpu_buffer_size), "cuMemsetD8");
+        if (litepcie_dma_init_gpu(&dma, litepcie_device,
+            (uint64_t)gpu_buffer, gpu_buffer_size)) {
+            cuMemFree(gpu_allocation);
+            cuCtxDestroy(gpu_context);
+            exit(1);
+        }
+    } else
+#endif
+    if (litepcie_dma_init(&dma, litepcie_device, zero_copy)) {
         exit(1);
+    }
 
     dma.reader_enable = 1;
     dma.writer_enable = 1;
@@ -390,59 +446,66 @@ static void dma_test(uint8_t zero_copy, uint8_t external_loopback, int data_widt
         litepcie_dma_process(&dma);
 
 #ifdef DMA_CHECK_DATA
-        char *buf_wr;
-        char *buf_rd;
+        if (!gpu_mode) {
+            char *buf_wr;
+            char *buf_rd;
 
-        /* DMA-TX Write. */
-        while (1) {
-            /* Get Write buffer. */
-            buf_wr = litepcie_dma_next_write_buffer(&dma);
-            /* Break when no buffer available for Write. */
-            if (!buf_wr)
-                break;
-            /* Write data to buffer. */
-            write_pn_data((uint32_t *) buf_wr, DMA_BUFFER_SIZE / sizeof(uint32_t), &seed_wr, data_width);
-        }
-
-        /* DMA-RX Read/Check */
-        while (1) {
-            /* Get Read buffer. */
-            buf_rd = litepcie_dma_next_read_buffer(&dma);
-            /* Break when no buffer available for Read. */
-            if (!buf_rd)
-                break;
-            /* Skip the first 128 DMA loops. */
-            if (dma.writer_hw_count < 128*DMA_BUFFER_COUNT)
-                break;
-            /* When running... */
-            if (run) {
-                /* Check data in Read buffer. */
-                errors += check_pn_data((uint32_t *) buf_rd, DMA_BUFFER_SIZE / sizeof(uint32_t), &seed_rd, data_width);
-                /* Clear Read buffer */
-                memset(buf_rd, 0, DMA_BUFFER_SIZE);
-            } else {
-                /* Find initial Delay/Seed (Useful when loopback is introducing delay). */
-                uint32_t errors_min = 0xffffffff;
-                for (int delay = 0; delay < DMA_BUFFER_SIZE / sizeof(uint32_t); delay++) {
-                    seed_rd = delay;
-                    errors = check_pn_data((uint32_t *) buf_rd, DMA_BUFFER_SIZE / sizeof(uint32_t), &seed_rd, data_width);
-                    //printf("delay: %d / errors: %d\n", delay, errors);
-                    if (errors < errors_min)
-                        errors_min = errors;
-                    if (errors < (DMA_BUFFER_SIZE / sizeof(uint32_t)) / 2) {
-                        printf("RX_DELAY: %d (errors: %d)\n", delay, errors);
-                        run = 1;
-                        break;
-                    }
-                }
-                if (!run) {
-                    printf("Unable to find DMA RX_DELAY (min errors: %d/%ld), exiting.\n",
-                        errors_min,
-                        DMA_BUFFER_SIZE / sizeof(uint32_t));
-                    goto end;
-                }
+            /* DMA-TX Write. */
+            while (1) {
+                /* Get Write buffer. */
+                buf_wr = litepcie_dma_next_write_buffer(&dma);
+                /* Break when no buffer available for Write. */
+                if (!buf_wr)
+                    break;
+                /* Write data to buffer. */
+                write_pn_data((uint32_t *) buf_wr, DMA_BUFFER_SIZE / sizeof(uint32_t), &seed_wr, data_width);
             }
 
+            /* DMA-RX Read/Check */
+            while (1) {
+                /* Get Read buffer. */
+                buf_rd = litepcie_dma_next_read_buffer(&dma);
+                /* Break when no buffer available for Read. */
+                if (!buf_rd)
+                    break;
+                /* Skip the first 128 DMA loops. */
+                if (dma.writer_hw_count < 128*DMA_BUFFER_COUNT)
+                    break;
+                /* When running... */
+                if (run) {
+                    /* Check data in Read buffer. */
+                    errors += check_pn_data((uint32_t *) buf_rd, DMA_BUFFER_SIZE / sizeof(uint32_t), &seed_rd, data_width);
+                    /* Clear Read buffer */
+                    memset(buf_rd, 0, DMA_BUFFER_SIZE);
+                } else {
+                    /* Find initial Delay/Seed (Useful when loopback is introducing delay). */
+                    uint32_t errors_min = 0xffffffff;
+                    for (int delay = 0; delay < DMA_BUFFER_SIZE / sizeof(uint32_t); delay++) {
+                        seed_rd = delay;
+                        errors = check_pn_data((uint32_t *) buf_rd, DMA_BUFFER_SIZE / sizeof(uint32_t), &seed_rd, data_width);
+                        //printf("delay: %d / errors: %d\n", delay, errors);
+                        if (errors < errors_min)
+                            errors_min = errors;
+                        if (errors < (DMA_BUFFER_SIZE / sizeof(uint32_t)) / 2) {
+                            printf("RX_DELAY: %d (errors: %d)\n", delay, errors);
+                            run = 1;
+                            break;
+                        }
+                    }
+                    if (!run) {
+                        printf("Unable to find DMA RX_DELAY (min errors: %d/%ld), exiting.\n",
+                            errors_min,
+                            DMA_BUFFER_SIZE / sizeof(uint32_t));
+                        goto end;
+                    }
+                }
+
+            }
+        } else {
+            while (litepcie_dma_next_write_buffer(&dma))
+                ;
+            while (litepcie_dma_next_read_buffer(&dma))
+                ;
         }
 #endif
 
@@ -472,6 +535,12 @@ static void dma_test(uint8_t zero_copy, uint8_t external_loopback, int data_widt
 end:
 #endif
     litepcie_dma_cleanup(&dma);
+#ifdef LITEPCIE_NVIDIA_P2P
+    if (gpu_mode) {
+        cuda_check(cuMemFree(gpu_allocation), "cuMemFree");
+        cuda_check(cuCtxDestroy(gpu_context), "cuCtxDestroy");
+    }
+#endif
 }
 
 /* Help */
@@ -490,6 +559,9 @@ static void help(void)
            "-w data_width                     Width of data bus (default = 16).\n"
            "-a                                Automatic DMA RX-Delay calibration.\n"
            "-t duration                       Duration of the test in seconds (default = 0, infinite).\n"
+#ifdef LITEPCIE_NVIDIA_P2P
+           "-g device_num                     Use NVIDIA GPU memory for DMA.\n"
+#endif
            "\n"
            "available commands:\n"
            "info                              Get Board information.\n"
@@ -518,6 +590,7 @@ int main(int argc, char **argv)
     static int litepcie_data_width;
     static int litepcie_auto_rx_delay;
     static int test_duration = 0; /* Default to 0 for infinite duration.*/
+    static int gpu_device_num = -1;
 
     litepcie_device_num = 0;
     litepcie_data_width = 16;
@@ -527,7 +600,7 @@ int main(int argc, char **argv)
 
     /* Parameters. */
     for (;;) {
-        c = getopt(argc, argv, "hc:w:zeat:");
+        c = getopt(argc, argv, "hc:w:zeat:g:");
         if (c == -1)
             break;
         switch(c) {
@@ -551,6 +624,14 @@ int main(int argc, char **argv)
             break;
         case 't':
             test_duration = atoi(optarg);
+            break;
+        case 'g':
+#ifdef LITEPCIE_NVIDIA_P2P
+            gpu_device_num = atoi(optarg);
+#else
+            fprintf(stderr, "NVIDIA GPU DMA support is not enabled\n");
+            exit(1);
+#endif
             break;
         default:
             exit(1);
@@ -607,7 +688,8 @@ int main(int argc, char **argv)
             litepcie_device_external_loopback,
             litepcie_data_width,
             litepcie_auto_rx_delay,
-            test_duration);
+            test_duration,
+            gpu_device_num);
 
     /* Show help otherwise. */
     else


### PR DESCRIPTION
## Summary

- add optional NVIDIA GPUDirect RDMA mappings to the Linux DMA driver
- use the current persistent NVIDIA P2P pages API
- keep GPU mappings scoped to the open LitePCIe DMA channel
- preserve the existing CPU-backed coherent DMA path as the default
- add a CUDA-backed `litepcie_util -g <device> dma_test` counter/throughput test
- document build and runtime requirements

## Relation to #107

This supersedes #107, which can no longer be updated by maintainers and conflicts with the current driver. It preserves the original idea and credits Steve Kelly, Tim Besard and Elliot Saba.

Compared with the original implementation, this version does not replace device-wide DMA buffers. It maps GPU memory per open channel, handles both DMA directions explicitly, validates NVIDIA's returned page layout, serializes map/start/unmap operations, rejects CPU access to active GPU mappings, and releases mappings on both explicit cleanup and file close.

The changes are split into two commits:

- `f927274`: kernel, UAPI and liblitepcie mapping support
- `df2f18b`: CUDA utility mode and documentation

## Testing

- `python3 -m pytest -q -m "not slow"`: 85 passed, 21 deselected, 40 subtests passed
- normal and CUDA-enabled userspace builds
- normal and NVIDIA-enabled kernel module builds on Linux 5.15 and 6.8
- NVIDIA 595.71.05 `nv-p2p.h`

The NVIDIA-enabled module has the expected `modpost` warnings for `nvidia_p2p_*` symbols, which are resolved when the NVIDIA kernel module is loaded. A GPUDirect-capable GPU/PCIe hardware test is still required.
