### PR TITLE
tlp: deliver completions of non-posted configuration writes

### DIFF
--- a/litepcie/tlp/controller.py
+++ b/litepcie/tlp/controller.py
@@ -56,6 +56,15 @@ class LitePCIeTLPController(LiteXModule):
         # Connect Data-Path.
         self.comb += req_sink.connect(req_source, omit={"valid", "ready", "tag"})
 
+        # Posted requests (Memory Writes) complete on the link without a Completion TLP and can be
+        # sent directly. Non-Posted requests (Memory Reads, but also Configuration Writes) return
+        # a Completion and must allocate a tag/req_queue entry so it is steered back to the issuer.
+        req_posted = Signal()
+        if with_configuration:
+            self.comb += req_posted.eq(req_sink.we & ~req_sink.is_cfg)
+        else:
+            self.comb += req_posted.eq(req_sink.we)
+
         # FSM.
         self.req_fsm = req_fsm = ResetInserter()(FSM(reset_state="WAIT-REQ"))
         self.comb += [
@@ -66,10 +75,11 @@ class LitePCIeTLPController(LiteXModule):
         req_fsm.act("WAIT-REQ",
             # Wait for a TLP Request...
             If(req_sink.valid & req_sink.first,
-                # TLP Write: We can send the request directly.
-                If(req_sink.we,
+                # Posted TLP: We can send the request directly.
+                If(req_posted,
                    NextState("SEND-WRITE-REQ")
-                # TLP Read:  We can send the request when one tag available and space in req_queue.
+                # Non-Posted TLP: We can send the request when one tag available and space in
+                # req_queue.
                 ).Elif(tag_queue.source.valid & req_queue.sink.ready,
                    NextState("SEND-READ-REQ")
                 )

--- a/litepcie/tlp/controller.py
+++ b/litepcie/tlp/controller.py
@@ -160,6 +160,16 @@ class LitePCIeTLPController(LiteXModule):
         fill_tag = Signal(tag_bits)
         self.sync += If(self.ctrl_rst, fill_tag.eq(0))
 
+        # Only recycle tags within the pending-request range: a completion whose tag was not
+        # allocated from tag_queue (e.g. the fixed tag of a posted write, or a spurious TLP) is
+        # dropped by the reordering demux and must not push a truncated tag back to tag_queue,
+        # which would duplicate a tag potentially still in flight.
+        cmp_tag_in_range = Signal()
+        if tag_bits < len(cmp_reorder.tag):
+            self.comb += cmp_tag_in_range.eq(cmp_sink.tag[tag_bits:] == 0)
+        else:
+            self.comb += cmp_tag_in_range.eq(1)
+
         # Connect Data-Path.
         self.comb += cmp_sink.connect(cmp_reorder, omit={"valid", "ready"})
 
@@ -192,7 +202,7 @@ class LitePCIeTLPController(LiteXModule):
                 # (UR/CA): an error Cpl is zero-length (end stays 0), so without this the
                 # tag is never returned and the controller starves/deadlocks.
                 If(cmp_sink.end | cmp_sink.err,
-                    tag_queue.sink.valid.eq(1),
+                    tag_queue.sink.valid.eq(cmp_tag_in_range),
                     tag_queue.sink.tag.eq(cmp_sink.tag)
                 ),
                 NextState("WAIT")

--- a/litepcie/tlp/depacketizer.py
+++ b/litepcie/tlp/depacketizer.py
@@ -418,7 +418,16 @@ class LitePCIeTLPDepacketizer(LiteXModule):
                 cmp_source.last.eq(tlp_cmp.last),
                 cmp_source.len.eq(tlp_cmp.length),
                 cmp_source.byte_count.eq(tlp_cmp.byte_count),
-                cmp_source.end.eq(tlp_cmp.length == (tlp_cmp.byte_count[2:])),
+                cmp_source.end.eq(
+                    # CplD: the request is fully satisfied when this packet's Length covers the
+                    # remaining Byte Count (intermediate packets of a split read have Length <
+                    # Byte Count/4).
+                    (tlp_cmp.length == (tlp_cmp.byte_count[2:])) |
+                    # Cpl (without data, e.g. a Configuration Write completion): always terminal.
+                    # The Length field is reserved in data-less completions, so it cannot be
+                    # compared against Byte Count.
+                    (tlp_cmp.fmt == fmt_dict["cpl"])
+                ),
                 cmp_source.adr.eq(tlp_cmp.lower_address),
                 cmp_source.req_id.eq(tlp_cmp.requester_id),
                 cmp_source.cmp_id.eq(tlp_cmp.completer_id),

--- a/test/test_tlp_controller.py
+++ b/test/test_tlp_controller.py
@@ -180,6 +180,164 @@ class TestTLPController(unittest.TestCase):
         self.assertEqual([c["last"] for c in observed_completions], [0, 1, 0, 1])
         self.assertEqual([c["end"] for c in observed_completions], [0, 1, 0, 1])
 
+    def _issue_request(self, controller, *, we, is_cfg=0, channel=0, user_id=0, length_dwords=1,
+        timeout=32):
+        sink = controller.master_in.sink
+        issued = False
+        for _ in range(timeout):
+            yield sink.valid.eq(1)
+            yield sink.first.eq(1)
+            yield sink.last.eq(1)
+            yield sink.we.eq(we)
+            if hasattr(sink, "is_cfg"):
+                yield sink.is_cfg.eq(is_cfg)
+            yield sink.req_id.eq(0x1234)
+            yield sink.len.eq(length_dwords)
+            yield sink.channel.eq(channel)
+            yield sink.user_id.eq(user_id)
+            yield
+            if (yield sink.ready):
+                issued = True
+                break
+        yield sink.valid.eq(0)
+        yield sink.first.eq(0)
+        yield sink.last.eq(0)
+        yield sink.we.eq(0)
+        if hasattr(sink, "is_cfg"):
+            yield sink.is_cfg.eq(0)
+        yield
+        return issued
+
+    def test_cfg_write_allocates_tag_and_completes(self):
+        # A Configuration Write is Non-Posted: it must be sent with a tag allocated from
+        # tag_queue (not the fixed posted-write tag) so its data-less completion is steered
+        # back to the issuing port, and the tag must be recycled afterwards.
+        controller = LitePCIeTLPController(
+            data_width           = 128,
+            address_width        = 32,
+            max_pending_requests = 4,
+            cmp_bufs_buffered    = True,
+            with_configuration   = True,
+        )
+
+        observed_requests    = []
+        observed_completions = []
+
+        @passive
+        def monitor_requests():
+            source = controller.master_out.sink
+            while True:
+                yield source.ready.eq(1)
+                if (yield source.valid) and (yield source.ready):
+                    observed_requests.append({
+                        "tag":    (yield source.tag),
+                        "we":     (yield source.we),
+                        "is_cfg": (yield source.is_cfg),
+                    })
+                yield
+
+        @passive
+        def monitor_completions():
+            source = controller.master_in.source
+            while True:
+                yield source.ready.eq(1)
+                if (yield source.valid) and (yield source.ready):
+                    observed_completions.append({
+                        "channel": (yield source.channel),
+                        "user_id": (yield source.user_id),
+                        "first":   (yield source.first),
+                        "last":    (yield source.last),
+                        "end":     (yield source.end),
+                    })
+                yield
+
+        def stim():
+            yield
+            self.assertTrue((yield from self._issue_request(
+                controller, we=1, is_cfg=1, channel=3, user_id=0x33)))
+
+            while len(observed_requests) < 1:
+                yield
+
+            # The request must carry an allocated (in-range) tag, not the posted-write tag.
+            self.assertEqual(observed_requests[0]["we"],     1)
+            self.assertEqual(observed_requests[0]["is_cfg"], 1)
+            self.assertLess(observed_requests[0]["tag"],     4)
+
+            # Return the data-less completion (end=1, single header-only beat).
+            accepted = []
+            yield from self._push_completion(
+                controller,
+                tag      = observed_requests[0]["tag"],
+                channel  = 9,
+                user_id  = 0x99,
+                beats    = 1,
+                accepted = accepted,
+            )
+            self.assertEqual(accepted, [0])
+
+            timeout = 0
+            while len(observed_completions) < 1:
+                timeout += 1
+                if timeout > 32:
+                    self.fail("Timed out waiting for the cfg write completion")
+                yield
+
+            # Delivered with the issuer's channel/user_id restored from req_queue.
+            self.assertEqual(observed_completions[0]["channel"], 3)
+            self.assertEqual(observed_completions[0]["user_id"], 0x33)
+            self.assertEqual(observed_completions[0]["first"],   1)
+            self.assertEqual(observed_completions[0]["last"],    1)
+            self.assertEqual(observed_completions[0]["end"],     1)
+
+            # All four tags must be allocatable again (the cfg write's tag was recycled).
+            for i in range(4):
+                self.assertTrue((yield from self._issue_request(controller, we=0)))
+            self.assertFalse((yield from self._issue_request(controller, we=0)))
+
+            tags = [r["tag"] for r in observed_requests[1:5]]
+            self.assertEqual(len(set(tags)), 4)
+
+        run_simulation(controller, [stim(), monitor_requests(), monitor_completions()],
+            vcd_name=None)
+
+    def test_memory_write_remains_posted(self):
+        # Memory Writes are Posted: they must be sent immediately with the fixed tag, even
+        # when every tag is held by in-flight Non-Posted requests.
+        controller = LitePCIeTLPController(
+            data_width           = 128,
+            address_width        = 32,
+            max_pending_requests = 4,
+            cmp_bufs_buffered    = True,
+            with_configuration   = True,
+        )
+
+        observed_requests = []
+
+        @passive
+        def monitor_requests():
+            source = controller.master_out.sink
+            while True:
+                yield source.ready.eq(1)
+                if (yield source.valid) and (yield source.ready):
+                    observed_requests.append({
+                        "tag": (yield source.tag),
+                        "we":  (yield source.we),
+                    })
+                yield
+
+        def stim():
+            yield
+            # Exhaust all tags with in-flight reads.
+            for _ in range(4):
+                self.assertTrue((yield from self._issue_request(controller, we=0)))
+            # A Memory Write must still go through, with the fixed posted tag.
+            self.assertTrue((yield from self._issue_request(controller, we=1, is_cfg=0)))
+            self.assertEqual(observed_requests[4]["we"],  1)
+            self.assertEqual(observed_requests[4]["tag"], 32)
+
+        run_simulation(controller, [stim(), monitor_requests()], vcd_name=None)
+
     def test_out_of_range_completion_tag_not_recycled(self):
         # A completion whose tag was never allocated from tag_queue (e.g. the fixed tag of a
         # posted write, or a spurious TLP) must not be recycled: pushing its truncated value

--- a/test/test_tlp_controller.py
+++ b/test/test_tlp_controller.py
@@ -180,6 +180,78 @@ class TestTLPController(unittest.TestCase):
         self.assertEqual([c["last"] for c in observed_completions], [0, 1, 0, 1])
         self.assertEqual([c["end"] for c in observed_completions], [0, 1, 0, 1])
 
+    def test_out_of_range_completion_tag_not_recycled(self):
+        # A completion whose tag was never allocated from tag_queue (e.g. the fixed tag of a
+        # posted write, or a spurious TLP) must not be recycled: pushing its truncated value
+        # into tag_queue would duplicate a tag potentially still in flight.
+        controller = LitePCIeTLPController(
+            data_width           = 128,
+            address_width        = 32,
+            max_pending_requests = 4,
+            cmp_bufs_buffered    = True,
+        )
+
+        observed_requests = []
+
+        @passive
+        def monitor_requests():
+            source = controller.master_out.sink
+            while True:
+                yield source.ready.eq(1)
+                if (yield source.valid) and (yield source.ready):
+                    observed_requests.append((yield source.tag))
+                yield
+
+        def try_issue_read(index, timeout=32):
+            sink = controller.master_in.sink
+            issued = False
+            for _ in range(timeout):
+                yield sink.valid.eq(1)
+                yield sink.first.eq(1)
+                yield sink.last.eq(1)
+                yield sink.we.eq(0)
+                yield sink.adr.eq(index * 64)
+                yield sink.len.eq(8)
+                yield
+                if (yield sink.ready):
+                    issued = True
+                    break
+            yield sink.valid.eq(0)
+            yield sink.first.eq(0)
+            yield sink.last.eq(0)
+            yield
+            return issued
+
+        def stim():
+            yield
+            # Consume one tag with an in-flight read.
+            self.assertTrue((yield from try_issue_read(0)))
+
+            # Push a completion with an out-of-range tag (32): its data is dropped by the
+            # reordering demux and its tag must not be recycled into tag_queue.
+            accepted = []
+            yield from self._push_completion(
+                controller,
+                tag      = 32,
+                channel  = 0,
+                user_id  = 0,
+                beats    = 1,
+                accepted = accepted,
+            )
+            self.assertEqual(accepted, [0])
+
+            # The three remaining tags can still be allocated...
+            for i in range(1, 4):
+                self.assertTrue((yield from try_issue_read(i)))
+            # ...but no fifth request may issue: all four tags are in flight, and the bogus
+            # completion must not have refilled the queue with a duplicate.
+            self.assertFalse((yield from try_issue_read(4)))
+
+            self.assertEqual(len(observed_requests), 4)
+            self.assertEqual(len(set(observed_requests)), 4)
+
+        run_simulation(controller, [stim(), monitor_requests()], vcd_name=None)
+
     def test_completion_buffer_depth_matches_request_footprint(self):
         data_width = 128
         beats_needed = _completion_beats_for(data_width)

--- a/test/test_tlp_depacketizer.py
+++ b/test/test_tlp_depacketizer.py
@@ -1,0 +1,162 @@
+#
+# This file is part of LitePCIe.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import math
+import unittest
+
+from litex.gen import *
+
+from litepcie.tlp.depacketizer import LitePCIeTLPDepacketizer
+
+from test.model.tlp import CPL, CPLD
+
+
+def _swap32(dword):
+    return int.from_bytes(dword.to_bytes(4, "little"), "big")
+
+
+def _dwords2packet(data_width, dwords):
+    ratio  = data_width//32
+    length = math.ceil(len(dwords)/ratio)
+    dat    = [0]*length
+    be     = [0]*length
+    for n in range(length):
+        for i in reversed(range(ratio)):
+            dat[n] = dat[n] << 32
+            be[n]  = be[n] << 4
+            try:
+                dat[n] |= dwords[ratio*n + i]
+                be[n]  |= 0xF
+            except IndexError:
+                pass
+    return dat, be
+
+
+def _completion_dwords(*, with_data, length, byte_count, tag, status=0, data=[]):
+    cpl               = CPLD() if with_data else CPL()
+    cpl.fmt           = 0b10 if with_data else 0b00
+    cpl.type          = 0b01010
+    cpl.length        = length
+    cpl.byte_count    = byte_count
+    cpl.status        = status
+    cpl.requester_id  = 0x1234
+    cpl.completer_id  = 0x5678
+    cpl.tag           = tag
+    # Payload dwords are byte-swapped on the wire with endianness="big" (the header encode
+    # compensates internally); pre-swap so the decoded payload matches `data`.
+    return cpl.encode_dwords([_swap32(d) for d in data])
+
+
+class TestTLPDepacketizer(unittest.TestCase):
+    def _run_completion(self, data_width, dwords):
+        dut = LitePCIeTLPDepacketizer(
+            data_width   = data_width,
+            endianness   = "big",
+            capabilities = ["REQUEST", "COMPLETION"],
+        )
+        dat, be  = _dwords2packet(data_width, dwords)
+        observed = []
+
+        @passive
+        def monitor():
+            source = dut.cmp_source
+            while True:
+                yield source.ready.eq(1)
+                if (yield source.valid) and (yield source.ready):
+                    observed.append({
+                        "first": (yield source.first),
+                        "last":  (yield source.last),
+                        "end":   (yield source.end),
+                        "err":   (yield source.err),
+                        "tag":   (yield source.tag),
+                        "len":   (yield source.len),
+                        "dat":   (yield source.dat),
+                    })
+                yield
+
+        def stim():
+            yield
+            for beat_index, (d, b) in enumerate(zip(dat, be)):
+                while True:
+                    yield dut.sink.valid.eq(1)
+                    yield dut.sink.first.eq(beat_index == 0)
+                    yield dut.sink.last.eq(beat_index == (len(dat) - 1))
+                    yield dut.sink.dat.eq(d)
+                    yield dut.sink.be.eq(b)
+                    yield
+                    if (yield dut.sink.ready):
+                        break
+            yield dut.sink.valid.eq(0)
+            yield dut.sink.first.eq(0)
+            yield dut.sink.last.eq(0)
+            for _ in range(32):
+                yield
+
+        run_simulation(dut, [stim(), monitor()], vcd_name=None)
+        return observed
+
+    def test_dataless_cpl_asserts_end(self):
+        # A completion without data (e.g. the completion of a Configuration Write) is always
+        # terminal: end must assert even though Length (reserved in data-less completions)
+        # cannot be compared against Byte Count.
+        for data_width in [64, 128]:
+            with self.subTest(data_width=data_width):
+                dwords   = _completion_dwords(with_data=False, length=0, byte_count=4, tag=0x42)
+                observed = self._run_completion(data_width, dwords)
+                self.assertEqual(len(observed), 1)
+                self.assertEqual(observed[0]["first"], 1)
+                self.assertEqual(observed[0]["last"],  1)
+                self.assertEqual(observed[0]["end"],   1)
+                self.assertEqual(observed[0]["err"],   0)
+                self.assertEqual(observed[0]["tag"],   0x42)
+
+    def test_dataless_cpl_error_asserts_end_and_err(self):
+        # Unsupported Request: data-less completion with a non-zero status.
+        for data_width in [64, 128]:
+            with self.subTest(data_width=data_width):
+                dwords   = _completion_dwords(with_data=False, length=0, byte_count=4, tag=0x07,
+                                              status=1)
+                observed = self._run_completion(data_width, dwords)
+                self.assertEqual(len(observed), 1)
+                self.assertEqual(observed[0]["end"], 1)
+                self.assertEqual(observed[0]["err"], 1)
+
+    def test_single_cpld_asserts_end(self):
+        for data_width in [64, 128]:
+            with self.subTest(data_width=data_width):
+                dwords   = _completion_dwords(with_data=True, length=1, byte_count=4, tag=0x11,
+                                              data=[0xDEADBEEF])
+                observed = self._run_completion(data_width, dwords)
+                self.assertEqual(len(observed), 1)
+                self.assertEqual(observed[0]["end"], 1)
+                self.assertEqual(observed[0]["err"], 0)
+                self.assertEqual(observed[0]["len"], 1)
+                self.assertEqual(observed[0]["dat"] & 0xFFFFFFFF, 0xDEADBEEF)
+
+    def test_split_cpld_asserts_end_on_last_packet_only(self):
+        # A 256-byte read split into 64-byte completions: Byte Count counts down and only the
+        # packet whose Length covers the remaining Byte Count is terminal. `end` is a per-packet
+        # header property, asserted on every beat of the terminal packet (consumers gate on
+        # last & end).
+        for data_width in [64, 128]:
+            with self.subTest(data_width=data_width):
+                intermediate = _completion_dwords(with_data=True, length=16, byte_count=256,
+                                                  tag=0x21, data=list(range(16)))
+                final        = _completion_dwords(with_data=True, length=16, byte_count=64,
+                                                  tag=0x21, data=list(range(16)))
+                observed_intermediate = self._run_completion(data_width, intermediate)
+                observed_final        = self._run_completion(data_width, final)
+                self.assertGreater(len(observed_intermediate), 0)
+                self.assertGreater(len(observed_final), 0)
+                self.assertEqual([b["end"] for b in observed_intermediate],
+                                 [0]*len(observed_intermediate))
+                self.assertEqual([b["end"] for b in observed_final],
+                                 [1]*len(observed_final))
+                self.assertEqual(observed_final[-1]["last"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Stacked on #170. Configuration Writes are Non-Posted requests, but the TLP layer treated every `we=1` request as posted and mishandled the returning data-less completion at two levels — CfgWr0s applied on the device while the issuer timed out with an error. Three fixes, each independently safe:

1. **tlp/controller: only recycle in-range completion tags** — the completion FSM pushed every completion's tag back into `tag_queue` truncated to `tag_bits`; a completion whose tag was never allocated (e.g. an UR for a posted write's fixed tag 32) would inject a duplicate of a tag potentially still in flight, corrupting tag accounting.

2. **tlp/depacketizer: assert `end` on data-less completions** — `end` was derived only as `Length == Byte Count/4`, which never asserts for a Cpl without data (Length is reserved/0, Byte Count is 4). Consumers retiring on `end` timed out on perfectly successful completions. `end` now also asserts when `fmt` indicates a data-less completion (always terminal). Split CplD semantics unchanged; error completions now assert `end` in addition to `err` (in-tree consumers already retire on `end | err`).

3. **tlp/controller: track non-posted configuration writes** — route `we=1 & is_cfg` through the existing read path (tag allocation + `req_queue` entry) so the returning completion is buffered, reordered, delivered to the issuer, and its tag recycled. Memory Writes keep the direct posted path, ungated by tag availability; `with_configuration=False` elaborates identical logic to before.

## Validation

- Test suite: 115 passed (7 new tests: out-of-range tag recycling, data-less Cpl success/error decode, single/split CplD `end` semantics at 64/128-bit, cfg-write tag allocation/completion/recycling, posted Memory Write behavior). Each fix's test fails on the unfixed tree.
- Hardware (7-series RootPort, Gen2 x4 NVMe endpoint): configuration writes now complete with `err=0` and no timeout; a 1000-operation alternating cfg write/read soak shows clean tag recycling; full device bring-up regression (enumeration, BAR0 MMIO, Identify, block Write/Read with data verification) passes.