### PR TITLE
Harden S7 clocking and wide DMA completion handling

### DIFF
--- a/litepcie/common.py
+++ b/litepcie/common.py
@@ -110,6 +110,7 @@ def completion_layout(data_width, address_width=32):
 
         # Data Stream.
         ("dat",     data_width),
+        ("be",      data_width//8), # Valid payload bytes on the current beat.
 
         # Internal LitePCIe Routing/Identification.
         ("channel", 8), # Crossbar's channel (Used for internal routing).

--- a/litepcie/frontend/dma.py
+++ b/litepcie/frontend/dma.py
@@ -376,6 +376,17 @@ class LitePCIeDMAReader(LiteXModule):
         else:
             self.comb += self.desc_sink.connect(splitter.sink)
 
+        # Request Metadata ------------------------------------------------------------------------
+        # Completion TLPs are retired in request order, but their ``last`` only delimits an
+        # individual completion packet. Keep one entry per split request so the data stream can
+        # delimit the original DMA descriptor on the final request's last completion.
+        request_metadata = SyncFIFO(
+            [("descriptor_last", 1), ("last_disable", 1)],
+            endpoint.max_pending_requests,
+            buffered=True,
+        )
+        self.request_metadata = ResetInserter()(request_metadata)
+
         # User ID ----------------------------------------------------------------------------------
         last_user_id = Signal(8, reset=255)
         self.sync += If(port.sink.valid & port.sink.first & port.sink.ready,
@@ -402,17 +413,27 @@ class LitePCIeDMAReader(LiteXModule):
             self.comb += data_fifo.source.connect(self.data_conv.sink)
         else:
             self.comb += data_fifo.source.connect(self.data_conv.sink, omit={"be"})
+        request_end = Signal()
         self.comb += [
+            request_end.eq(port.sink.last & (port.sink.end | port.sink.err)),
             # When Enabled, connect Sink to Data FIFO.
             If(enable,
                 port.sink.connect(data_fifo.sink, keep={"valid", "ready"}),
                 data_fifo.sink.data.eq(port.sink.dat),
                 data_fifo.sink.be.eq(port.sink.be),
                 data_fifo.sink.first.eq(port.sink.first & (port.sink.user_id != last_user_id)),
+                data_fifo.sink.last.eq(
+                    request_end & request_metadata.source.valid &
+                    request_metadata.source.descriptor_last &
+                    ~request_metadata.source.last_disable
+                ),
             # Else accept incoming Port Data.
             ).Else(
                 port.sink.ready.eq(1)
-            )
+            ),
+            request_metadata.source.ready.eq(
+                enable & port.sink.valid & port.sink.ready & request_end
+            ),
         ]
 
         # Pending words ----------------------------------------------------------------------------
@@ -436,11 +457,21 @@ class LitePCIeDMAReader(LiteXModule):
 
         # FSM --------------------------------------------------------------------------------------
         self.fsm = fsm = FSM(reset_state="IDLE")
+        request_can_issue = Signal()
+        self.comb += [
+            request_can_issue.eq(request_metadata.sink.ready),
+            request_metadata.sink.valid.eq(
+                fsm.ongoing("MEM-RD-REQ") & port.source.valid & port.source.ready
+            ),
+            request_metadata.sink.descriptor_last.eq(splitter.source.last),
+            request_metadata.sink.last_disable.eq(splitter.source.last_disable),
+        ]
         fsm.act("IDLE",
             # Reset Splitter/FIFO when disabled.
             If(~enable,
                 splitter.reset.eq(1),
                 data_fifo.reset.eq(1),
+                request_metadata.reset.eq(1),
             # Else wait for a Descriptor and to have enough Space to generate the Request.
             ).Elif(splitter.source.valid & (pending_words < (data_fifo_depth - max_words_per_request)),
                 NextState("MEM-RD-REQ"),
@@ -462,9 +493,9 @@ class LitePCIeDMAReader(LiteXModule):
         ]
         fsm.act("MEM-RD-REQ",
             # Request Control-Path.
-            port.source.valid.eq(1),
+            port.source.valid.eq(request_can_issue),
             # When Request is accepted...
-            If(port.source.ready,
+            If(port.source.ready & request_can_issue,
                 # Accept Descriptor.
                 splitter.source.ready.eq(1),
                 # Return to Idle.

--- a/litepcie/frontend/dma.py
+++ b/litepcie/frontend/dma.py
@@ -23,11 +23,9 @@ def descriptor_layout(address_width=32, with_user_id=False):
         layout += [("user_id", 8)]
     return EndpointDescription(layout)
 
-
 def dma_words_for_bytes(length, data_width):
     data_width_bytes = data_width//8
     return (length + (data_width_bytes - 1)) >> log2_int(data_width_bytes)
-
 
 def dma_reader_layout(data_width):
     return EndpointDescription([
@@ -35,9 +33,13 @@ def dma_reader_layout(data_width):
         ("be",   data_width//8),
     ])
 
+# LitePCIe DMA Reader Down-Converter ---------------------------------------------------------------
 
 class LitePCIeDMAReaderDownConverter(LiteXModule):
-    """Downsize completion data while discarding invalid trailing subwords."""
+    """LitePCIe DMA Reader Down-Converter.
+
+    Downsize Completion data while discarding invalid trailing words.
+    """
     def __init__(self, data_width_from, data_width_to):
         assert data_width_from > data_width_to
         assert (data_width_from % data_width_to) == 0
@@ -45,50 +47,50 @@ class LitePCIeDMAReaderDownConverter(LiteXModule):
         self.sink   = sink   = stream.Endpoint(dma_reader_layout(data_width_from))
         self.source = source = stream.Endpoint(dma_layout(data_width_to))
 
-        ratio          = data_width_from//data_width_to
-        bytes_per_word = data_width_to//8
-        index           = Signal(max=ratio)
-        current_valid   = Signal()
-        later_valid     = Signal()
+        ratio      = data_width_from//data_width_to
+        word_bytes = data_width_to//8
+        mux         = Signal(max=ratio)
+        word_valid  = Signal()
+        words_left  = Signal()
 
         cases = {}
         for i in range(ratio):
-            following = [sink.be[j*bytes_per_word:(j+1)*bytes_per_word] != 0
+            following = [sink.be[j*word_bytes:(j+1)*word_bytes] != 0
                 for j in range(i + 1, ratio)]
             cases[i] = [
                 source.data.eq(sink.data[i*data_width_to:(i+1)*data_width_to]),
-                current_valid.eq(sink.be[i*bytes_per_word:(i+1)*bytes_per_word] != 0),
-                later_valid.eq(Reduce("OR", following) if following else 0),
+                word_valid.eq(sink.be[i*word_bytes:(i+1)*word_bytes] != 0),
+                words_left.eq(Reduce("OR", following) if following else 0),
             ]
 
         self.comb += [
-            current_valid.eq(0),
-            later_valid.eq(0),
-            Case(index, cases),
-            source.valid.eq(sink.valid & current_valid),
-            source.first.eq(sink.first & (index == 0)),
-            source.last.eq(sink.last & ~later_valid),
-            If(current_valid,
-                sink.ready.eq(source.ready & ~later_valid),
+            word_valid.eq(0),
+            words_left.eq(0),
+            Case(mux, cases),
+            source.valid.eq(sink.valid & word_valid),
+            source.first.eq(sink.first & (mux == 0)),
+            source.last.eq(sink.last & ~words_left),
+            If(word_valid,
+                sink.ready.eq(source.ready & ~words_left),
             ).Else(
-                sink.ready.eq(~later_valid),
+                sink.ready.eq(~words_left),
             ),
         ]
 
         self.sync += If(sink.valid,
-            If(current_valid,
+            If(word_valid,
                 If(source.ready,
-                    If(later_valid,
-                        index.eq(index + 1),
+                    If(words_left,
+                        mux.eq(mux + 1),
                     ).Else(
-                        index.eq(0),
+                        mux.eq(0),
                     ),
                 ),
             ).Else(
-                If(later_valid,
-                    index.eq(index + 1),
+                If(words_left,
+                    mux.eq(mux + 1),
                 ).Else(
-                    index.eq(0),
+                    mux.eq(0),
                 ),
             ),
         )
@@ -376,16 +378,15 @@ class LitePCIeDMAReader(LiteXModule):
         else:
             self.comb += self.desc_sink.connect(splitter.sink)
 
-        # Request Metadata ------------------------------------------------------------------------
-        # Completion TLPs are retired in request order, but their ``last`` only delimits an
-        # individual completion packet. Keep one entry per split request so the data stream can
-        # delimit the original DMA descriptor on the final request's last completion.
-        request_metadata = SyncFIFO(
-            [("descriptor_last", 1), ("last_disable", 1)],
-            endpoint.max_pending_requests,
-            buffered=True,
-        )
-        self.request_metadata = ResetInserter()(request_metadata)
+        # Request Metadata -------------------------------------------------------------------------
+        # Completion TLPs are retired in request order, but last only delimits an individual
+        # Completion packet. Keep one entry per split request to delimit the original DMA
+        # descriptor on the final request's last Completion.
+        self.request_metadata = request_metadata = ResetInserter()(SyncFIFO(
+            layout   = [("descriptor_last", 1), ("last_disable", 1)],
+            depth    = endpoint.max_pending_requests,
+            buffered = True,
+        ))
 
         # User ID ----------------------------------------------------------------------------------
         last_user_id = Signal(8, reset=255)
@@ -401,21 +402,24 @@ class LitePCIeDMAReader(LiteXModule):
             data_conv = LitePCIeDMAReaderDownConverter(endpoint.phy.data_width, self.data_width)
         else:
             data_conv = stream.Converter(endpoint.phy.data_width, self.data_width)
-        self.data_conv = ResetInserter()(data_conv)
-        self.comb += self.data_conv.reset.eq(~enable)
-        self.comb += self.data_conv.source.connect(self.source)
+        self.data_conv = data_conv = ResetInserter()(data_conv)
+        self.comb += data_conv.reset.eq(~enable)
+        self.comb += data_conv.source.connect(self.source)
 
         # Data FIFO --------------------------------------------------------------------------------
         data_fifo_depth = 4*max_pending_words
-        data_fifo = SyncFIFO(dma_reader_layout(endpoint.phy.data_width), data_fifo_depth, buffered=True)
-        self.data_fifo = ResetInserter()(data_fifo)
+        self.data_fifo = data_fifo = ResetInserter()(SyncFIFO(
+            layout   = dma_reader_layout(endpoint.phy.data_width),
+            depth    = data_fifo_depth,
+            buffered = True,
+        ))
         if endpoint.phy.data_width > self.data_width:
-            self.comb += data_fifo.source.connect(self.data_conv.sink)
+            self.comb += data_fifo.source.connect(data_conv.sink)
         else:
-            self.comb += data_fifo.source.connect(self.data_conv.sink, omit={"be"})
-        request_end = Signal()
+            self.comb += data_fifo.source.connect(data_conv.sink, omit={"be"})
+        request_done = Signal()
         self.comb += [
-            request_end.eq(port.sink.last & (port.sink.end | port.sink.err)),
+            request_done.eq(port.sink.last & (port.sink.end | port.sink.err)),
             # When Enabled, connect Sink to Data FIFO.
             If(enable,
                 port.sink.connect(data_fifo.sink, keep={"valid", "ready"}),
@@ -423,7 +427,7 @@ class LitePCIeDMAReader(LiteXModule):
                 data_fifo.sink.be.eq(port.sink.be),
                 data_fifo.sink.first.eq(port.sink.first & (port.sink.user_id != last_user_id)),
                 data_fifo.sink.last.eq(
-                    request_end & request_metadata.source.valid &
+                    request_done & request_metadata.source.valid &
                     request_metadata.source.descriptor_last &
                     ~request_metadata.source.last_disable
                 ),
@@ -432,7 +436,7 @@ class LitePCIeDMAReader(LiteXModule):
                 port.sink.ready.eq(1)
             ),
             request_metadata.source.ready.eq(
-                enable & port.sink.valid & port.sink.ready & request_end
+                enable & port.sink.valid & port.sink.ready & request_done
             ),
         ]
 
@@ -457,9 +461,7 @@ class LitePCIeDMAReader(LiteXModule):
 
         # FSM --------------------------------------------------------------------------------------
         self.fsm = fsm = FSM(reset_state="IDLE")
-        request_can_issue = Signal()
         self.comb += [
-            request_can_issue.eq(request_metadata.sink.ready),
             request_metadata.sink.valid.eq(
                 fsm.ongoing("MEM-RD-REQ") & port.source.valid & port.source.ready
             ),
@@ -493,9 +495,9 @@ class LitePCIeDMAReader(LiteXModule):
         ]
         fsm.act("MEM-RD-REQ",
             # Request Control-Path.
-            port.source.valid.eq(request_can_issue),
+            port.source.valid.eq(request_metadata.sink.ready),
             # When Request is accepted...
-            If(port.source.ready & request_can_issue,
+            If(port.source.valid & port.source.ready,
                 # Accept Descriptor.
                 splitter.source.ready.eq(1),
                 # Return to Idle.

--- a/litepcie/frontend/dma.py
+++ b/litepcie/frontend/dma.py
@@ -29,6 +29,71 @@ def dma_words_for_bytes(length, data_width):
     return (length + (data_width_bytes - 1)) >> log2_int(data_width_bytes)
 
 
+def dma_reader_layout(data_width):
+    return EndpointDescription([
+        ("data", data_width),
+        ("be",   data_width//8),
+    ])
+
+
+class LitePCIeDMAReaderDownConverter(LiteXModule):
+    """Downsize completion data while discarding invalid trailing subwords."""
+    def __init__(self, data_width_from, data_width_to):
+        assert data_width_from > data_width_to
+        assert (data_width_from % data_width_to) == 0
+
+        self.sink   = sink   = stream.Endpoint(dma_reader_layout(data_width_from))
+        self.source = source = stream.Endpoint(dma_layout(data_width_to))
+
+        ratio          = data_width_from//data_width_to
+        bytes_per_word = data_width_to//8
+        index           = Signal(max=ratio)
+        current_valid   = Signal()
+        later_valid     = Signal()
+
+        cases = {}
+        for i in range(ratio):
+            following = [sink.be[j*bytes_per_word:(j+1)*bytes_per_word] != 0
+                for j in range(i + 1, ratio)]
+            cases[i] = [
+                source.data.eq(sink.data[i*data_width_to:(i+1)*data_width_to]),
+                current_valid.eq(sink.be[i*bytes_per_word:(i+1)*bytes_per_word] != 0),
+                later_valid.eq(Reduce("OR", following) if following else 0),
+            ]
+
+        self.comb += [
+            current_valid.eq(0),
+            later_valid.eq(0),
+            Case(index, cases),
+            source.valid.eq(sink.valid & current_valid),
+            source.first.eq(sink.first & (index == 0)),
+            source.last.eq(sink.last & ~later_valid),
+            If(current_valid,
+                sink.ready.eq(source.ready & ~later_valid),
+            ).Else(
+                sink.ready.eq(~later_valid),
+            ),
+        ]
+
+        self.sync += If(sink.valid,
+            If(current_valid,
+                If(source.ready,
+                    If(later_valid,
+                        index.eq(index + 1),
+                    ).Else(
+                        index.eq(0),
+                    ),
+                ),
+            ).Else(
+                If(later_valid,
+                    index.eq(index + 1),
+                ).Else(
+                    index.eq(0),
+                ),
+            ),
+        )
+
+
 # LitePCIeDMAScatterGather --------------------------------------------------------------------------
 
 class LitePCIeDMAScatterGather(LiteXModule):
@@ -321,21 +386,28 @@ class LitePCIeDMAReader(LiteXModule):
 
         # Reset with the DMA: a partial beat held across a disable would shift the next run's
         # stream by a sub-beat word offset (visible as misaligned DMA headers on restart).
-        self.data_conv = ResetInserter()(stream.Converter(endpoint.phy.data_width, self.data_width))
+        if endpoint.phy.data_width > self.data_width:
+            data_conv = LitePCIeDMAReaderDownConverter(endpoint.phy.data_width, self.data_width)
+        else:
+            data_conv = stream.Converter(endpoint.phy.data_width, self.data_width)
+        self.data_conv = ResetInserter()(data_conv)
         self.comb += self.data_conv.reset.eq(~enable)
         self.comb += self.data_conv.source.connect(self.source)
 
         # Data FIFO --------------------------------------------------------------------------------
         data_fifo_depth = 4*max_pending_words
-        data_fifo = SyncFIFO(dma_layout(endpoint.phy.data_width), data_fifo_depth, buffered=True)
+        data_fifo = SyncFIFO(dma_reader_layout(endpoint.phy.data_width), data_fifo_depth, buffered=True)
         self.data_fifo = ResetInserter()(data_fifo)
+        if endpoint.phy.data_width > self.data_width:
+            self.comb += data_fifo.source.connect(self.data_conv.sink)
+        else:
+            self.comb += data_fifo.source.connect(self.data_conv.sink, omit={"be"})
         self.comb += [
-            # Connect Data FIFO to Data Converter.
-            data_fifo.source.connect(self.data_conv.sink),
             # When Enabled, connect Sink to Data FIFO.
             If(enable,
                 port.sink.connect(data_fifo.sink, keep={"valid", "ready"}),
                 data_fifo.sink.data.eq(port.sink.dat),
+                data_fifo.sink.be.eq(port.sink.be),
                 data_fifo.sink.first.eq(port.sink.first & (port.sink.user_id != last_user_id)),
             # Else accept incoming Port Data.
             ).Else(

--- a/litepcie/phy/s7pciephy.py
+++ b/litepcie/phy/s7pciephy.py
@@ -116,7 +116,20 @@ class S7PCIEPHY(LiteXModule):
         assert data_width      in [64, 128]
         assert pcie_data_width in [64, 128]
         assert refclk_freq     in [100e6, 125e6, 250e6]
-        self.user_clk_freq = max(125e6, nlanes*62.5e6*64/pcie_data_width)
+        user_clk_freqs = {
+            (1,  64) : 125e6,
+            (1, 128) : 125e6,
+            (2,  64) : 125e6,
+            (2, 128) : 125e6,
+            (4,  64) : 250e6,
+            (4, 128) : 125e6,
+            (8, 128) : 250e6,
+        }
+        if (nlanes, pcie_data_width) not in user_clk_freqs:
+            raise ValueError(
+                f"S7PCIEPHY: Gen2 x{nlanes} does not support a {pcie_data_width}-bit PCIe "
+                "datapath.")
+        self.user_clk_freq = user_clk_freqs[nlanes, pcie_data_width]
 
         # Clocking / Reset -------------------------------------------------------------------------
         self.pcie_refclk = pcie_refclk = Signal()

--- a/litepcie/phy/s7pciephy.py
+++ b/litepcie/phy/s7pciephy.py
@@ -116,6 +116,7 @@ class S7PCIEPHY(LiteXModule):
         assert data_width      in [64, 128]
         assert pcie_data_width in [64, 128]
         assert refclk_freq     in [100e6, 125e6, 250e6]
+        self.user_clk_freq = max(125e6, nlanes*62.5e6*64/pcie_data_width)
 
         # Clocking / Reset -------------------------------------------------------------------------
         self.pcie_refclk = pcie_refclk = Signal()
@@ -209,7 +210,7 @@ class S7PCIEPHY(LiteXModule):
 
         # MMCM.
         userclk1_freq = {1:125e6, 2:125e6, 4:250e6, 8:500e6}[nlanes]
-        userclk2_freq = {1:125e6, 2:125e6, 4:125e6, 8:250e6}[nlanes]
+        userclk2_freq = self.user_clk_freq
         self.mmcm = mmcm = S7MMCM(speedgrade=mmcm_speedgrade)
         self.specials += Instance("BUFG",
             i_I = pipe_txoutclk,
@@ -590,7 +591,7 @@ class S7PCIEPHY(LiteXModule):
             link_speed         = "5.0_GT/s"
             maximum_link_width = f"X{self.nlanes}"
             ref_clk_freq       = f"{int(self.refclk_freq/1e6)}_MHz"
-            user_clk_freq      = 125 if self.nlanes != 8 else 250
+            user_clk_freq      = int(self.user_clk_freq/1e6)
 
             # Interface.
             interface_width = f"{self.pcie_data_width}_bit"

--- a/litepcie/phy/s7pciephy.py
+++ b/litepcie/phy/s7pciephy.py
@@ -20,8 +20,8 @@ from litepcie.phy.common import *
 # S7PCIEPHY ----------------------------------------------------------------------------------------
 
 class S7PCIEPHY(LiteXModule):
-    endianness    = "big"
-    qword_aligned = False
+    endianness      = "big"
+    qword_aligned   = False
     gt_channel_path = {
         "gtp": "gtp_channel.gtpe2_channel_i",
         "gtx": "gtx_channel.gtxe2_channel_i",
@@ -116,7 +116,7 @@ class S7PCIEPHY(LiteXModule):
         assert data_width      in [64, 128]
         assert pcie_data_width in [64, 128]
         assert refclk_freq     in [100e6, 125e6, 250e6]
-        user_clk_freqs = {
+        userclk_freqs = {
             (1,  64) : 125e6,
             (1, 128) : 125e6,
             (2,  64) : 125e6,
@@ -125,11 +125,11 @@ class S7PCIEPHY(LiteXModule):
             (4, 128) : 125e6,
             (8, 128) : 250e6,
         }
-        if (nlanes, pcie_data_width) not in user_clk_freqs:
+        if (nlanes, pcie_data_width) not in userclk_freqs:
             raise ValueError(
                 f"S7PCIEPHY: Gen2 x{nlanes} does not support a {pcie_data_width}-bit PCIe "
                 "datapath.")
-        self.user_clk_freq = user_clk_freqs[nlanes, pcie_data_width]
+        self.userclk_freq = userclk_freqs[nlanes, pcie_data_width]
 
         # Clocking / Reset -------------------------------------------------------------------------
         self.pcie_refclk = pcie_refclk = Signal()
@@ -223,7 +223,7 @@ class S7PCIEPHY(LiteXModule):
 
         # MMCM.
         userclk1_freq = {1:125e6, 2:125e6, 4:250e6, 8:500e6}[nlanes]
-        userclk2_freq = self.user_clk_freq
+        userclk2_freq = self.userclk_freq
         self.mmcm = mmcm = S7MMCM(speedgrade=mmcm_speedgrade)
         self.specials += Instance("BUFG",
             i_I = pipe_txoutclk,
@@ -604,7 +604,7 @@ class S7PCIEPHY(LiteXModule):
             link_speed         = "5.0_GT/s"
             maximum_link_width = f"X{self.nlanes}"
             ref_clk_freq       = f"{int(self.refclk_freq/1e6)}_MHz"
-            user_clk_freq      = int(self.user_clk_freq/1e6)
+            user_clk_freq      = int(self.userclk_freq/1e6)
 
             # Interface.
             interface_width = f"{self.pcie_data_width}_bit"

--- a/litepcie/tlp/controller.py
+++ b/litepcie/tlp/controller.py
@@ -14,6 +14,11 @@ from litepcie.tlp.common  import *
 
 # LitePCIe TLP Controller --------------------------------------------------------------------------
 
+def completion_buffer_depth(data_width, max_request_size_bytes=max_request_size):
+    beat_bytes = data_width//8
+    return (max_request_size_bytes + beat_bytes - 1)//beat_bytes
+
+
 class LitePCIeTLPController(LiteXModule):
     """LitePCIe TLP requests/completions controller.
 
@@ -128,7 +133,7 @@ class LitePCIeTLPController(LiteXModule):
 
         # Create Buffers.
         if cmp_buf_depth is None:
-            cmp_buf_depth = 4*max_request_size//(data_width//8)
+            cmp_buf_depth = completion_buffer_depth(data_width)
         for i in range(max_pending_requests):
             cmp_buf       = ResetInserter()(SyncFIFO(completion_layout(data_width), cmp_buf_depth, buffered=cmp_bufs_buffered))
             cmp_bufs.append(cmp_buf)

--- a/litepcie/tlp/controller.py
+++ b/litepcie/tlp/controller.py
@@ -12,19 +12,16 @@ from litepcie.common      import *
 from litepcie.core.common import *
 from litepcie.tlp.common  import *
 
-# LitePCIe TLP Controller --------------------------------------------------------------------------
+# Helpers ------------------------------------------------------------------------------------------
 
-def completion_buffer_depth(data_width, max_request_size_bytes=max_request_size):
-    """Return a safe per-tag completion buffer depth.
-
-    Completion payloads are repacked independently at each TLP boundary. A request that is not
-    aligned to the datapath can therefore occupy one more stream beat than its byte count alone
-    implies (partial first and last Completion TLPs cannot share a beat).
-    """
-    beat_bytes = data_width//8
+def get_completion_buffer_depth(data_width, max_request_size_bytes=max_request_size):
+    # Completion payloads are repacked independently at each TLP boundary. An unaligned request
+    # can use one additional stream beat since partial first/last Completion TLPs cannot share one.
+    beat_bytes    = data_width//8
     request_beats = (max_request_size_bytes + beat_bytes - 1)//beat_bytes
     return request_beats + 1
 
+# LitePCIe TLP Controller --------------------------------------------------------------------------
 
 class LitePCIeTLPController(LiteXModule):
     """LitePCIe TLP requests/completions controller.
@@ -140,7 +137,7 @@ class LitePCIeTLPController(LiteXModule):
 
         # Create Buffers.
         if cmp_buf_depth is None:
-            cmp_buf_depth = completion_buffer_depth(data_width)
+            cmp_buf_depth = get_completion_buffer_depth(data_width)
         for i in range(max_pending_requests):
             cmp_buf       = ResetInserter()(SyncFIFO(completion_layout(data_width), cmp_buf_depth, buffered=cmp_bufs_buffered))
             cmp_bufs.append(cmp_buf)
@@ -167,12 +164,9 @@ class LitePCIeTLPController(LiteXModule):
             req_queue.source.connect(cmp_source, keep={"channel", "user_id"}),
         ]
 
-        # A tag remains owned by its request until the buffered completion retires in request order.
-        # Recycling it when the completion merely arrives allows a younger request to reuse the tag
-        # while the previous completion still occupies the same reorder FIFO. If that FIFO fills, the
-        # younger completion can then block an older completion needed to make forward progress.
-        retire_tag = Signal()
-        self.comb += retire_tag.eq(
+        # Retire Tag once the buffered Completion has been consumed in request order.
+        tag_retire = Signal()
+        self.comb += tag_retire.eq(
             cmp_source.valid & cmp_source.ready & cmp_source.last &
             (cmp_source.end | cmp_source.err)
         )
@@ -198,7 +192,7 @@ class LitePCIeTLPController(LiteXModule):
             )
         )
         cmp_fsm.act("WAIT",
-            tag_queue.sink.valid.eq(retire_tag),
+            tag_queue.sink.valid.eq(tag_retire),
             tag_queue.sink.tag.eq(req_queue.source.tag),
             # Wait for a TLP Completion...
             If(cmp_sink.valid & cmp_sink.first,
@@ -208,7 +202,7 @@ class LitePCIeTLPController(LiteXModule):
             )
         )
         cmp_fsm.act("RUN",
-            tag_queue.sink.valid.eq(retire_tag),
+            tag_queue.sink.valid.eq(tag_retire),
             tag_queue.sink.tag.eq(req_queue.source.tag),
             # Connect Control-Path.
             cmp_sink.connect(cmp_reorder, keep={"valid", "ready"}),

--- a/litepcie/tlp/controller.py
+++ b/litepcie/tlp/controller.py
@@ -15,8 +15,15 @@ from litepcie.tlp.common  import *
 # LitePCIe TLP Controller --------------------------------------------------------------------------
 
 def completion_buffer_depth(data_width, max_request_size_bytes=max_request_size):
+    """Return a safe per-tag completion buffer depth.
+
+    Completion payloads are repacked independently at each TLP boundary. A request that is not
+    aligned to the datapath can therefore occupy one more stream beat than its byte count alone
+    implies (partial first and last Completion TLPs cannot share a beat).
+    """
     beat_bytes = data_width//8
-    return (max_request_size_bytes + beat_bytes - 1)//beat_bytes
+    request_beats = (max_request_size_bytes + beat_bytes - 1)//beat_bytes
+    return request_beats + 1
 
 
 class LitePCIeTLPController(LiteXModule):

--- a/litepcie/tlp/controller.py
+++ b/litepcie/tlp/controller.py
@@ -14,12 +14,13 @@ from litepcie.tlp.common  import *
 
 # Helpers ------------------------------------------------------------------------------------------
 
-def get_completion_buffer_depth(data_width, max_request_size_bytes=max_request_size):
+def get_completion_buffer_depth(data_width, max_request_size_bytes=max_request_size, buffered=False):
     # Completion payloads are repacked independently at each TLP boundary. An unaligned request
     # can use one additional stream beat since partial first/last Completion TLPs cannot share one.
     beat_bytes    = data_width//8
     request_beats = (max_request_size_bytes + beat_bytes - 1)//beat_bytes
-    return request_beats + 1
+    # A buffered SyncFIFO already provides the additional beat in its output register.
+    return request_beats + (0 if buffered else 1)
 
 # LitePCIe TLP Controller --------------------------------------------------------------------------
 
@@ -137,7 +138,7 @@ class LitePCIeTLPController(LiteXModule):
 
         # Create Buffers.
         if cmp_buf_depth is None:
-            cmp_buf_depth = get_completion_buffer_depth(data_width)
+            cmp_buf_depth = get_completion_buffer_depth(data_width, buffered=cmp_bufs_buffered)
         for i in range(max_pending_requests):
             cmp_buf       = ResetInserter()(SyncFIFO(completion_layout(data_width), cmp_buf_depth, buffered=cmp_bufs_buffered))
             cmp_bufs.append(cmp_buf)

--- a/litepcie/tlp/controller.py
+++ b/litepcie/tlp/controller.py
@@ -155,10 +155,20 @@ class LitePCIeTLPController(LiteXModule):
             # which would otherwise leave the request un-retired and leak its tag,
             # deadlocking the DMA reader.
             If(cmp_source.valid & cmp_source.last & (cmp_source.end | cmp_source.err),
-                req_queue.source.ready.eq(cmp_source.ready)
+                req_queue.source.ready.eq(cmp_source.ready),
             ),
             req_queue.source.connect(cmp_source, keep={"channel", "user_id"}),
         ]
+
+        # A tag remains owned by its request until the buffered completion retires in request order.
+        # Recycling it when the completion merely arrives allows a younger request to reuse the tag
+        # while the previous completion still occupies the same reorder FIFO. If that FIFO fills, the
+        # younger completion can then block an older completion needed to make forward progress.
+        retire_tag = Signal()
+        self.comb += retire_tag.eq(
+            cmp_source.valid & cmp_source.ready & cmp_source.last &
+            (cmp_source.end | cmp_source.err)
+        )
 
         # Completions Management -------------------------------------------------------------------
 
@@ -181,6 +191,8 @@ class LitePCIeTLPController(LiteXModule):
             )
         )
         cmp_fsm.act("WAIT",
+            tag_queue.sink.valid.eq(retire_tag),
+            tag_queue.sink.tag.eq(req_queue.source.tag),
             # Wait for a TLP Completion...
             If(cmp_sink.valid & cmp_sink.first,
                 NextState("RUN")
@@ -189,17 +201,11 @@ class LitePCIeTLPController(LiteXModule):
             )
         )
         cmp_fsm.act("RUN",
+            tag_queue.sink.valid.eq(retire_tag),
+            tag_queue.sink.tag.eq(req_queue.source.tag),
             # Connect Control-Path.
             cmp_sink.connect(cmp_reorder, keep={"valid", "ready"}),
-            # Push incoming Tag to tag_queue when Cmp is fully received.
             If(cmp_sink.valid & cmp_sink.ready & cmp_sink.last,
-                # Free the tag on a normal end-of-completion OR on an error completion
-                # (UR/CA): an error Cpl is zero-length (end stays 0), so without this the
-                # tag is never returned and the controller starves/deadlocks.
-                If(cmp_sink.end | cmp_sink.err,
-                    tag_queue.sink.valid.eq(1),
-                    tag_queue.sink.tag.eq(cmp_sink.tag)
-                ),
                 NextState("WAIT")
             )
         )

--- a/litepcie/tlp/depacketizer.py
+++ b/litepcie/tlp/depacketizer.py
@@ -426,7 +426,8 @@ class LitePCIeTLPDepacketizer(LiteXModule):
                 cmp_source.attr.eq(tlp_cmp.attr),
                 cmp_source.err.eq(tlp_cmp.status != 0),
                 cmp_source.tag.eq(tlp_cmp.tag),
-                cmp_source.dat.eq(tlp_cmp.dat)
+                cmp_source.dat.eq(tlp_cmp.dat),
+                cmp_source.be.eq(tlp_cmp.be),
             ]
 
         # Decode/Dispatch TLP Configurations -------------------------------------------------------

--- a/litepcie/tlp/depacketizer.py
+++ b/litepcie/tlp/depacketizer.py
@@ -39,8 +39,10 @@ class _LitePCIeTLPHeaderExtracter(LiteXModule):
             be_r.eq(sink.be),
         )
 
-        first = Signal()
-        last  = Signal()  # "flush pending"
+        first      = Signal()
+        last       = Signal()  # "flush pending"
+        tail_valid = Signal()
+        self.comb += tail_valid.eq(sink.be[4*shift_dws:] != 0)
 
         # Helpers ----------------------------------------------------------------------------------
 
@@ -107,15 +109,21 @@ class _LitePCIeTLPHeaderExtracter(LiteXModule):
         fsm.act("COPY",
             source.valid.eq(sink.valid | last),
             source.first.eq(first),
-            source.last.eq(sink.last | last),
+            source.last.eq(last | (sink.last & ~tail_valid)),
 
             *_emit_shifted(dat_r, be_r, sink.dat, sink.be),
 
             If(source.valid & source.ready,
                 NextValue(first, 0),
                 sink.ready.eq(~last),  # already acked when last=1
-                If(source.last,
+                If(last,
                     NextState("IDLE")
+                ).Elif(sink.last,
+                    If(tail_valid,
+                        NextValue(last, 1),
+                    ).Else(
+                        NextState("IDLE")
+                    )
                 )
             )
         )
@@ -199,11 +207,13 @@ class LitePCIeTLPHeaderExtracter64b(LiteXModule):
 
         # # #
 
-        first = Signal()
-        last  = Signal()
-        count = Signal()
-        dat   = Signal(64,    reset_less=True)
-        be    = Signal(64//8, reset_less=True)
+        first      = Signal()
+        last       = Signal()
+        count      = Signal()
+        dat        = Signal(64,    reset_less=True)
+        be         = Signal(64//8, reset_less=True)
+        tail_valid = Signal()
+        self.comb += tail_valid.eq(sink.be[4*1:4*2] != 0)
         self.sync += \
             If(sink.valid & sink.ready,
                 dat.eq(sink.dat),
@@ -234,11 +244,19 @@ class LitePCIeTLPHeaderExtracter64b(LiteXModule):
         fsm.act("COPY",
             source.valid.eq(sink.valid | last),
             source.first.eq(first),
-            source.last.eq(sink.last | last),
+            source.last.eq(last | (sink.last & ~tail_valid)),
             If(source.valid & source.ready,
                 NextValue(first, 0),
-                sink.ready.eq(1 & ~last),
-                If(source.last, NextState("IDLE"))
+                sink.ready.eq(~last),
+                If(last,
+                    NextState("IDLE")
+                ).Elif(sink.last,
+                    If(tail_valid,
+                        NextValue(last, 1),
+                    ).Else(
+                        NextState("IDLE")
+                    )
+                )
             )
         )
         self.comb += [

--- a/litepcie/tlp/depacketizer.py
+++ b/litepcie/tlp/depacketizer.py
@@ -40,7 +40,7 @@ class _LitePCIeTLPHeaderExtracter(LiteXModule):
         )
 
         first      = Signal()
-        last       = Signal()  # "flush pending"
+        flush      = Signal()
         tail_valid = Signal()
         self.comb += tail_valid.eq(sink.be[4*shift_dws:] != 0)
 
@@ -70,7 +70,7 @@ class _LitePCIeTLPHeaderExtracter(LiteXModule):
             for lane in range(left_lanes, dws_per_beat):
                 in_lane = lane - left_lanes
                 stmts += [
-                    If(last,
+                    If(flush,
                         _dw(source.dat, lane).eq(0),
                         _be(source.be,  lane).eq(0),
                     ).Else(
@@ -87,7 +87,7 @@ class _LitePCIeTLPHeaderExtracter(LiteXModule):
 
         fsm.act("IDLE",
             NextValue(first, 1),
-            NextValue(last,  0),
+            NextValue(flush, 0),
             If(sink.valid,
                 NextState("HEADER")
             )
@@ -100,27 +100,27 @@ class _LitePCIeTLPHeaderExtracter(LiteXModule):
                 NextValue(source.header[32*2:32*3], sink.dat[32*2:32*3]),
                 NextValue(source.header[32*3:32*4], sink.dat[32*3:32*4]),
                 If(sink.last,
-                    NextValue(last, 1)
+                    NextValue(flush, 1)
                 ),
                 NextState("COPY")
             )
         )
 
         fsm.act("COPY",
-            source.valid.eq(sink.valid | last),
+            source.valid.eq(sink.valid | flush),
             source.first.eq(first),
-            source.last.eq(last | (sink.last & ~tail_valid)),
+            source.last.eq(flush | (sink.last & ~tail_valid)),
 
             *_emit_shifted(dat_r, be_r, sink.dat, sink.be),
 
             If(source.valid & source.ready,
                 NextValue(first, 0),
-                sink.ready.eq(~last),  # already acked when last=1
-                If(last,
+                sink.ready.eq(~flush),
+                If(flush,
                     NextState("IDLE")
                 ).Elif(sink.last,
                     If(tail_valid,
-                        NextValue(last, 1),
+                        NextValue(flush, 1),
                     ).Else(
                         NextState("IDLE")
                     )
@@ -208,7 +208,7 @@ class LitePCIeTLPHeaderExtracter64b(LiteXModule):
         # # #
 
         first      = Signal()
-        last       = Signal()
+        flush      = Signal()
         count      = Signal()
         dat        = Signal(64,    reset_less=True)
         be         = Signal(64//8, reset_less=True)
@@ -223,7 +223,7 @@ class LitePCIeTLPHeaderExtracter64b(LiteXModule):
         self.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
             NextValue(first, 1),
-            NextValue(last,  0),
+            NextValue(flush, 0),
             NextValue(count, 0),
             If(sink.valid, NextState("HEADER"))
         )
@@ -236,23 +236,23 @@ class LitePCIeTLPHeaderExtracter64b(LiteXModule):
                 NextValue(source.header[32*2:32*3],      sink.dat[32*0:32*1]),
                 NextValue(source.header[32*3:32*4],      sink.dat[32*1:32*2]),
                 If(count,
-                    If(sink.last, NextValue(last, 1)),
+                    If(sink.last, NextValue(flush, 1)),
                     NextState("COPY")
                 )
             )
         )
         fsm.act("COPY",
-            source.valid.eq(sink.valid | last),
+            source.valid.eq(sink.valid | flush),
             source.first.eq(first),
-            source.last.eq(last | (sink.last & ~tail_valid)),
+            source.last.eq(flush | (sink.last & ~tail_valid)),
             If(source.valid & source.ready,
                 NextValue(first, 0),
-                sink.ready.eq(~last),
-                If(last,
+                sink.ready.eq(~flush),
+                If(flush,
                     NextState("IDLE")
                 ).Elif(sink.last,
                     If(tail_valid,
-                        NextValue(last, 1),
+                        NextValue(flush, 1),
                     ).Else(
                         NextState("IDLE")
                     )
@@ -261,13 +261,13 @@ class LitePCIeTLPHeaderExtracter64b(LiteXModule):
         )
         self.comb += [
             source.dat[32*0:32*1].eq(     dat[32*1:32*2]),
-            If(last,
+            If(flush,
                 source.dat[32*1:32*2].eq(0),
             ).Else(
                 source.dat[32*1:32*2].eq(sink.dat[32*0:32*1]),
             ),
             source.be[  4*0: 4*1].eq(     be[4*1:4*2]),
-            If(last,
+            If(flush,
                 source.be[  4*1: 4*2].eq(0),
             ).Else(
                 source.be[  4*1: 4*2].eq(sink.be[4*0:4*1])

--- a/litepcie/tlp/packetizer.py
+++ b/litepcie/tlp/packetizer.py
@@ -595,6 +595,20 @@ class LitePCIeTLPPacketizer(LiteXModule):
 
         if "REQUEST" in capabilities:
             self.tlp_req = tlp_req = stream.Endpoint(tlp_request_layout(data_width))
+
+            request_be = Signal(data_width//8)
+            self.comb += request_be.eq(2**(data_width//8)-1)
+            dwords_per_beat = data_width//32
+            if dwords_per_beat > 1:
+                remainder_bits = (dwords_per_beat - 1).bit_length()
+                remainder_cases = {
+                    n : request_be.eq(2**(4*n)-1)
+                    for n in range(1, dwords_per_beat)
+                }
+                self.comb += If(req_sink.last,
+                    Case(req_sink.len[:remainder_bits], remainder_cases)
+                )
+
             self.comb += [
                 If(~req_is_cfg,
                     tlp_req.valid.eq(req_sink.valid),
@@ -662,11 +676,7 @@ class LitePCIeTLPPacketizer(LiteXModule):
                 tlp_req.first_be.eq(0xf),
                 tlp_req.dat.eq(req_sink.dat),
                 If(req_sink.we,
-                    If(req_sink.len == 1,
-                        tlp_req.be.eq(0xf)
-                    ).Else(
-                        tlp_req.be.eq(2**(data_width//8)-1)
-                    )
+                    tlp_req.be.eq(request_be)
                 ).Else(
                     tlp_req.be.eq(0x00)
                 )

--- a/test/test_dma.py
+++ b/test/test_dma.py
@@ -299,3 +299,13 @@ class TestDMA(unittest.TestCase):
     @pytest.mark.slow
     def test_dma_512b_data_width_64b_address_width(self):
         self.dma_test(data_width=512, address_width=64)
+
+    @pytest.mark.slow
+    def test_dma_512b_data_width_64b_address_width_32byte_tails(self):
+        self.dma_test(
+            data_width         = 512,
+            address_width      = 64,
+            descriptor_lengths = [544, 544],
+            chipset_split      = True,
+            chipset_reordering = True,
+        )

--- a/test/test_dma.py
+++ b/test/test_dma.py
@@ -153,8 +153,8 @@ class TestDMA(unittest.TestCase):
         self.assertEqual(dma_words_for_bytes(512, 128), 32)
 
     def dma_test(self, data_width, address_width, descriptor_lengths=None, test_size=256,
-        chipset_split=True, chipset_reordering=True, dma_data_width=None, check_reader_stream=False,
-        reader_last_disable=False, timeout_cycles=20000):
+        chipset_split=True, chipset_reordering=True, dma_data_width=None,
+        check_reader_stream=False, reader_last_disable=False, timeout_cycles=20000):
         if descriptor_lengths is None:
             descriptor_lengths = [test_size//4] * 4
         test_size = sum(descriptor_lengths)
@@ -165,6 +165,9 @@ class TestDMA(unittest.TestCase):
         host_data     = [seed_to_data(i, True) for i in range(test_size//4)]
         loopback_data = []
         reader_data   = []
+        stream_width  = dma_data_width or data_width
+        reader_words  = sum(
+            dma_words_for_bytes(length, stream_width) for length in descriptor_lengths)
 
         @passive
         def reader_monitor(dut):
@@ -219,8 +222,10 @@ class TestDMA(unittest.TestCase):
                     write_offset += length
 
             # Enable MSI.
-            yield dut.msi.enable.storage.eq(
-                DMA_READER_IRQ | (0 if check_reader_stream else DMA_WRITER_IRQ))
+            msi_enable = DMA_READER_IRQ
+            if not check_reader_stream:
+                msi_enable |= DMA_WRITER_IRQ
+            yield dut.msi.enable.storage.eq(msi_enable)
 
             # Enable DMA Reader & Writer.
             yield from dma_reader_driver.enable()
@@ -229,17 +234,19 @@ class TestDMA(unittest.TestCase):
 
             # Wait for all reader words or writes.
             timeout = 0
-            stream_width = dma_data_width or data_width
-            expected_reader_words = sum(
-                dma_words_for_bytes(length, stream_width) for length in descriptor_lengths)
-            while ((len(reader_data) < expected_reader_words) if check_reader_stream else
-                   (dut.msi_handler.dma_writer_irq_count != len(descriptor_lengths))):
+            while True:
+                if check_reader_stream:
+                    done = (len(reader_data) >= reader_words)
+                else:
+                    done = (dut.msi_handler.dma_writer_irq_count == len(descriptor_lengths))
+                if done:
+                    break
                 timeout += 1
                 if timeout > timeout_cycles:
                     self.fail(
                         f"DMA loopback timed out (width={data_width}, address_width={address_width}, "
                         f"descriptors={descriptor_lengths}, writes={dut.msi_handler.dma_writer_irq_count}, "
-                        f"reader_words={len(reader_data)}/{expected_reader_words})"
+                        f"reader_words={len(reader_data)}/{reader_words})"
                     )
                 yield
 
@@ -306,11 +313,8 @@ class TestDMA(unittest.TestCase):
         run_simulation(dut, generators, clocks, vcd_name=_vcd_name("test_dma.vcd"))
         if not check_reader_stream:
             self.assertEqual(host_data, loopback_data)
-        if check_reader_stream:
-            stream_width = dma_data_width or data_width
-            expected_reader_words = sum(
-                dma_words_for_bytes(length, stream_width) for length in descriptor_lengths)
-            self.assertEqual(expected_reader_words, len(reader_data))
+        else:
+            self.assertEqual(reader_words, len(reader_data))
             expected_last_indices = []
             word_count = 0
             for length, last_disable in zip(descriptor_lengths, reader_last_disable):
@@ -383,26 +387,26 @@ class TestDMA(unittest.TestCase):
     @pytest.mark.slow
     def test_dma_512b_phy_256b_stream_64b_address_width_32byte_tails(self):
         self.dma_test(
-            data_width         = 512,
-            dma_data_width     = 256,
-            address_width      = 64,
-            descriptor_lengths = [544, 544],
-            chipset_split      = True,
-            chipset_reordering = True,
+            data_width          = 512,
+            dma_data_width      = 256,
+            address_width       = 64,
+            descriptor_lengths  = [544, 544],
+            chipset_split       = True,
+            chipset_reordering  = True,
             check_reader_stream = True,
         )
 
     @pytest.mark.slow
     def test_dma_reader_last_disable(self):
         self.dma_test(
-            data_width         = 512,
-            dma_data_width     = 256,
-            address_width      = 64,
-            descriptor_lengths = [544, 544],
-            chipset_split      = True,
-            chipset_reordering = True,
+            data_width          = 512,
+            dma_data_width      = 256,
+            address_width       = 64,
+            descriptor_lengths  = [544, 544],
+            chipset_split       = True,
+            chipset_reordering  = True,
             check_reader_stream = True,
-            reader_last_disable = [False, True],
+            reader_last_disable  = [False, True],
         )
 
     @pytest.mark.slow

--- a/test/test_dma.py
+++ b/test/test_dma.py
@@ -154,7 +154,7 @@ class TestDMA(unittest.TestCase):
 
     def dma_test(self, data_width, address_width, descriptor_lengths=None, test_size=256,
         chipset_split=True, chipset_reordering=True, dma_data_width=None, check_reader_stream=False,
-        reader_last_disable=False):
+        reader_last_disable=False, timeout_cycles=20000):
         if descriptor_lengths is None:
             descriptor_lengths = [test_size//4] * 4
         test_size = sum(descriptor_lengths)
@@ -235,18 +235,18 @@ class TestDMA(unittest.TestCase):
             while ((len(reader_data) < expected_reader_words) if check_reader_stream else
                    (dut.msi_handler.dma_writer_irq_count != len(descriptor_lengths))):
                 timeout += 1
-                if timeout > 20000:
+                if timeout > timeout_cycles:
                     self.fail(
                         f"DMA loopback timed out (width={data_width}, address_width={address_width}, "
-                        f"descriptors={descriptor_lengths}, writes={dut.msi_handler.dma_writer_irq_count})"
+                        f"descriptors={descriptor_lengths}, writes={dut.msi_handler.dma_writer_irq_count}, "
+                        f"reader_words={len(reader_data)}/{expected_reader_words})"
                     )
                 yield
 
-            # Delay to ensure all the data has been written.
-            for i in range(1024):
-                yield
-
             if not check_reader_stream:
+                # Delay to ensure all the data has been written.
+                for i in range(1024):
+                    yield
                 for data in dut.host.read_mem(test_size, test_size):
                     loopback_data.append(data)
 
@@ -339,6 +339,20 @@ class TestDMA(unittest.TestCase):
             chipset_split      = False,
             chipset_reordering = False,
         )
+
+    @pytest.mark.slow
+    def test_dma_s7_reader_descriptor_boundaries(self):
+        for data_width in [64, 128]:
+            with self.subTest(data_width=data_width):
+                self.dma_test(
+                    data_width          = data_width,
+                    address_width       = 32,
+                    descriptor_lengths  = [28, 36, 60, 68],
+                    chipset_split       = True,
+                    chipset_reordering  = True,
+                    check_reader_stream = True,
+                    timeout_cycles      = 1000,
+                )
 
     @pytest.mark.slow
     def test_dma_256b_data_width_32b_address_width(self):

--- a/test/test_dma.py
+++ b/test/test_dma.py
@@ -351,3 +351,14 @@ class TestDMA(unittest.TestCase):
             chipset_reordering = True,
             check_reader_stream = True,
         )
+
+    @pytest.mark.slow
+    def test_dma_512b_phy_256b_stream_64b_address_width_32byte_tails_loopback(self):
+        self.dma_test(
+            data_width         = 512,
+            dma_data_width     = 256,
+            address_width      = 64,
+            descriptor_lengths = [544, 544],
+            chipset_split      = True,
+            chipset_reordering = True,
+        )

--- a/test/test_dma.py
+++ b/test/test_dma.py
@@ -152,13 +152,21 @@ class TestDMA(unittest.TestCase):
         self.assertEqual(dma_words_for_bytes(512, 128), 32)
 
     def dma_test(self, data_width, address_width, descriptor_lengths=None, test_size=256,
-        chipset_split=True, chipset_reordering=True):
+        chipset_split=True, chipset_reordering=True, dma_data_width=None, check_reader_stream=False):
         if descriptor_lengths is None:
             descriptor_lengths = [test_size//4] * 4
         test_size = sum(descriptor_lengths)
 
         host_data     = [seed_to_data(i, True) for i in range(test_size//4)]
         loopback_data = []
+        reader_data   = []
+
+        @passive
+        def reader_monitor(dut):
+            while True:
+                if (yield dut.dma_reader.source.valid) and (yield dut.dma_reader.source.ready):
+                    reader_data.append((yield dut.dma_reader.source.data))
+                yield
 
         def main_generator(dut):
             # Allocate Host's Memory.
@@ -172,7 +180,8 @@ class TestDMA(unittest.TestCase):
 
             # DMA Reader/Writer control models.
             dma_reader_driver = DMADriver("dma_reader", dut)
-            dma_writer_driver = DMADriver("dma_writer", dut)
+            if not check_reader_stream:
+                dma_writer_driver = DMADriver("dma_writer", dut)
 
             # Program DMA Reader descriptors.
             yield from dma_reader_driver.set_prog_mode()
@@ -183,23 +192,30 @@ class TestDMA(unittest.TestCase):
                 read_offset += length
 
             # Program DMA Writer descriptors.
-            yield from dma_writer_driver.set_prog_mode()
-            yield from dma_writer_driver.flush()
-            write_offset = test_size
-            for length in descriptor_lengths:
-                yield from dma_writer_driver.program_descriptor(write_offset, length)
-                write_offset += length
+            if not check_reader_stream:
+                yield from dma_writer_driver.set_prog_mode()
+                yield from dma_writer_driver.flush()
+                write_offset = test_size
+                for length in descriptor_lengths:
+                    yield from dma_writer_driver.program_descriptor(write_offset, length)
+                    write_offset += length
 
             # Enable MSI.
-            yield dut.msi.enable.storage.eq(DMA_READER_IRQ | DMA_WRITER_IRQ)
+            yield dut.msi.enable.storage.eq(
+                DMA_READER_IRQ | (0 if check_reader_stream else DMA_WRITER_IRQ))
 
             # Enable DMA Reader & Writer.
             yield from dma_reader_driver.enable()
-            yield from dma_writer_driver.enable()
+            if not check_reader_stream:
+                yield from dma_writer_driver.enable()
 
-            # Wait for all writes.
+            # Wait for all reader words or writes.
             timeout = 0
-            while dut.msi_handler.dma_writer_irq_count != len(descriptor_lengths):
+            stream_width = dma_data_width or data_width
+            expected_reader_words = sum(
+                dma_words_for_bytes(length, stream_width) for length in descriptor_lengths)
+            while ((len(reader_data) < expected_reader_words) if check_reader_stream else
+                   (dut.msi_handler.dma_writer_irq_count != len(descriptor_lengths))):
                 timeout += 1
                 if timeout > 20000:
                     self.fail(
@@ -212,8 +228,9 @@ class TestDMA(unittest.TestCase):
             for i in range(1024):
                 yield
 
-            for data in dut.host.read_mem(test_size, test_size):
-                loopback_data.append(data)
+            if not check_reader_stream:
+                for data in dut.host.read_mem(test_size, test_size):
+                    loopback_data.append(data)
 
 
         class DUT(LiteXModule):
@@ -238,9 +255,14 @@ class TestDMA(unittest.TestCase):
                 # DMA Reader/Writer ----------------------------------------------------------------
                 dma_reader_port = self.endpoint.crossbar.get_master_port(read_only=True)
                 dma_writer_port = self.endpoint.crossbar.get_master_port(write_only=True)
-                self.dma_reader = LitePCIeDMAReader(self.endpoint, dma_reader_port, address_width=address_width)
-                self.dma_writer = LitePCIeDMAWriter(self.endpoint, dma_writer_port, address_width=address_width)
-                self.comb += self.dma_reader.source.connect(self.dma_writer.sink)
+                self.dma_reader = LitePCIeDMAReader(self.endpoint, dma_reader_port,
+                    address_width=address_width, data_width=dma_data_width)
+                self.dma_writer = LitePCIeDMAWriter(self.endpoint, dma_writer_port,
+                    address_width=address_width, data_width=dma_data_width)
+                if check_reader_stream:
+                    self.comb += self.dma_reader.source.ready.eq(1)
+                else:
+                    self.comb += self.dma_reader.source.connect(self.dma_writer.sink)
 
                 # MSI ------------------------------------------------------------------------------
                 self.msi = LitePCIeMSI(2)
@@ -262,9 +284,17 @@ class TestDMA(unittest.TestCase):
                 dut.host.phy.phy_source.generator()
             ]
         }
+        if check_reader_stream:
+            generators["sys"].append(reader_monitor(dut))
         clocks = {"sys": 10}
         run_simulation(dut, generators, clocks, vcd_name=_vcd_name("test_dma.vcd"))
-        self.assertEqual(host_data, loopback_data)
+        if not check_reader_stream:
+            self.assertEqual(host_data, loopback_data)
+        if check_reader_stream:
+            stream_width = dma_data_width or data_width
+            expected_reader_words = sum(
+                dma_words_for_bytes(length, stream_width) for length in descriptor_lengths)
+            self.assertEqual(expected_reader_words, len(reader_data))
 
     @pytest.mark.slow
     def test_dma_64b_data_width_32b_address_width(self):
@@ -308,4 +338,16 @@ class TestDMA(unittest.TestCase):
             descriptor_lengths = [544, 544],
             chipset_split      = True,
             chipset_reordering = True,
+        )
+
+    @pytest.mark.slow
+    def test_dma_512b_phy_256b_stream_64b_address_width_32byte_tails(self):
+        self.dma_test(
+            data_width         = 512,
+            dma_data_width     = 256,
+            address_width      = 64,
+            descriptor_lengths = [544, 544],
+            chipset_split      = True,
+            chipset_reordering = True,
+            check_reader_stream = True,
         )

--- a/test/test_dma.py
+++ b/test/test_dma.py
@@ -79,11 +79,12 @@ class DMADriver:
     def flush(self):
         yield from self.dma.table.reset.write(1)
 
-    def program_descriptor(self, address, length):
+    def program_descriptor(self, address, length, last_disable=False):
         address_lsb = (address >>  0) & 0xffff_ffff
         address_msb = (address >> 32) & 0xffff_ffff
         value = address_lsb
         value |= (length << 32)
+        value |= (int(last_disable) << 57)
         yield from self.dma.table.value.write(value)
         yield from self.dma.table.we.write(address_msb)
 
@@ -152,10 +153,14 @@ class TestDMA(unittest.TestCase):
         self.assertEqual(dma_words_for_bytes(512, 128), 32)
 
     def dma_test(self, data_width, address_width, descriptor_lengths=None, test_size=256,
-        chipset_split=True, chipset_reordering=True, dma_data_width=None, check_reader_stream=False):
+        chipset_split=True, chipset_reordering=True, dma_data_width=None, check_reader_stream=False,
+        reader_last_disable=False):
         if descriptor_lengths is None:
             descriptor_lengths = [test_size//4] * 4
         test_size = sum(descriptor_lengths)
+        if isinstance(reader_last_disable, bool):
+            reader_last_disable = [reader_last_disable] * len(descriptor_lengths)
+        assert len(reader_last_disable) == len(descriptor_lengths)
 
         host_data     = [seed_to_data(i, True) for i in range(test_size//4)]
         loopback_data = []
@@ -163,9 +168,18 @@ class TestDMA(unittest.TestCase):
 
         @passive
         def reader_monitor(dut):
+            cycle = 0
+            yield dut.dma_reader.source.ready.eq(1)
+            yield
             while True:
                 if (yield dut.dma_reader.source.valid) and (yield dut.dma_reader.source.ready):
-                    reader_data.append((yield dut.dma_reader.source.data))
+                    reader_data.append((
+                        (yield dut.dma_reader.source.data),
+                        (yield dut.dma_reader.source.last),
+                    ))
+                # Exercise descriptor delimitation under periodic backpressure.
+                yield dut.dma_reader.source.ready.eq((cycle % 4) != 0)
+                cycle += 1
                 yield
 
         def main_generator(dut):
@@ -187,8 +201,12 @@ class TestDMA(unittest.TestCase):
             yield from dma_reader_driver.set_prog_mode()
             yield from dma_reader_driver.flush()
             read_offset = 0
-            for length in descriptor_lengths:
-                yield from dma_reader_driver.program_descriptor(read_offset, length)
+            for length, last_disable in zip(descriptor_lengths, reader_last_disable):
+                yield from dma_reader_driver.program_descriptor(
+                    read_offset,
+                    length,
+                    last_disable=last_disable,
+                )
                 read_offset += length
 
             # Program DMA Writer descriptors.
@@ -259,9 +277,7 @@ class TestDMA(unittest.TestCase):
                     address_width=address_width, data_width=dma_data_width)
                 self.dma_writer = LitePCIeDMAWriter(self.endpoint, dma_writer_port,
                     address_width=address_width, data_width=dma_data_width)
-                if check_reader_stream:
-                    self.comb += self.dma_reader.source.ready.eq(1)
-                else:
+                if not check_reader_stream:
                     self.comb += self.dma_reader.source.connect(self.dma_writer.sink)
 
                 # MSI ------------------------------------------------------------------------------
@@ -295,6 +311,16 @@ class TestDMA(unittest.TestCase):
             expected_reader_words = sum(
                 dma_words_for_bytes(length, stream_width) for length in descriptor_lengths)
             self.assertEqual(expected_reader_words, len(reader_data))
+            expected_last_indices = []
+            word_count = 0
+            for length, last_disable in zip(descriptor_lengths, reader_last_disable):
+                word_count += dma_words_for_bytes(length, stream_width)
+                if not last_disable:
+                    expected_last_indices.append(word_count - 1)
+            self.assertEqual(
+                [index for index, (_, last) in enumerate(reader_data) if last],
+                expected_last_indices,
+            )
 
     @pytest.mark.slow
     def test_dma_64b_data_width_32b_address_width(self):
@@ -350,6 +376,19 @@ class TestDMA(unittest.TestCase):
             chipset_split      = True,
             chipset_reordering = True,
             check_reader_stream = True,
+        )
+
+    @pytest.mark.slow
+    def test_dma_reader_last_disable(self):
+        self.dma_test(
+            data_width         = 512,
+            dma_data_width     = 256,
+            address_width      = 64,
+            descriptor_lengths = [544, 544],
+            chipset_split      = True,
+            chipset_reordering = True,
+            check_reader_stream = True,
+            reader_last_disable = [False, True],
         )
 
     @pytest.mark.slow

--- a/test/test_header_extracter.py
+++ b/test/test_header_extracter.py
@@ -98,11 +98,10 @@ def _rand_payload_dws_and_be(max_dws, allow_empty=False):
 
 def _model_extracter_output_beats(data_width, phy_beats):
     """
-    Model the current RTL behavior in COPY.
+    Model the shifted COPY output, including a final beat when valid tail DWORDs remain.
 
     >=128b: COPY builds output beat i from prev + curr:
         out_dws = prev[3:] + curr[:3]
-      (For 128b, BE has a known RTL quirk, handled below.)
 
     64b: HEADER consumes 2 beats, then COPY is effectively:
         out = [prev.dw1] + [curr.dw0]
@@ -158,12 +157,20 @@ def _model_extracter_output_beats(data_width, phy_beats):
         for i in range(2, len(phy_beats)):
             prev = phy_beats[i-1]
             curr = phy_beats[i]
+            tail_valid = any(curr["be"][1:])
             out_beats.append({
                 "first": 1 if i == 2 else 0,
-                "last" : 1 if curr["last"] else 0,
+                "last" : 1 if curr["last"] and not tail_valid else 0,
                 "dws"  : [prev["dws"][1], curr["dws"][0]],
                 "be"   : [prev["be"][1],  curr["be"][0]],
             })
+            if curr["last"] and tail_valid:
+                out_beats.append({
+                    "first": 0,
+                    "last" : 1,
+                    "dws"  : [curr["dws"][1], 0],
+                    "be"   : [curr["be"][1],  0],
+                })
         return out_beats
 
     # >=128b data path is the same for 128/256/512.
@@ -179,12 +186,20 @@ def _model_extracter_output_beats(data_width, phy_beats):
             curr = phy_beats[i]
             out_dws = prev["dws"][cut:] + curr["dws"][:cut]
             out_be  = prev["be"][cut:]  + curr["be"][:cut]
+            tail_valid = any(curr["be"][cut:])
             out_beats.append({
                 "first": 1 if i == 1 else 0,
-                "last" : 1 if curr["last"] else 0,
+                "last" : 1 if curr["last"] and not tail_valid else 0,
                 "dws"  : out_dws,
                 "be"   : out_be,
             })
+            if curr["last"] and tail_valid:
+                out_beats.append({
+                    "first": 0,
+                    "last" : 1,
+                    "dws"  : curr["dws"][cut:] + [0] * cut,
+                    "be"   : curr["be"][cut:]  + [0] * cut,
+                })
 
     # Sanity.
     for b in out_beats:
@@ -254,8 +269,9 @@ class TestLitePCIeTLPHeaderExtracter(unittest.TestCase):
 
         @passive
         def monitor(dut):
+            cycle = 0
             while True:
-                yield dut.source.ready.eq(1)
+                yield dut.source.ready.eq((cycle % 4) != 0)
                 if (yield dut.source.valid) and (yield dut.source.ready):
                     ndws = _dws_per_beat(data_width)
                     got_beats.append({
@@ -265,6 +281,7 @@ class TestLitePCIeTLPHeaderExtracter(unittest.TestCase):
                         "be"   : _unpack_be_to_nibbles((yield dut.source.be),  ndws),
                     })
                     got_headers.append((yield dut.source.header))
+                cycle += 1
                 yield
 
         def stimulus(dut):
@@ -353,6 +370,16 @@ class TestLitePCIeTLPHeaderExtracter(unittest.TestCase):
             header_4dws        = header_4dws,
             payload_dws        = [0x00010203, 0x04050607, 0x08090A0B],
             payload_be_nibbles = [0xF, 0xF, 0x3],
+        )
+
+        # 3DW, payload requiring a final shifted-tail flush.
+        payload_dws = [0x10000000 + i for i in range(_dws_per_beat(data_width) + 1)]
+        self._run_case(
+            data_width         = data_width,
+            header_dws         = 3,
+            header_4dws        = header_4dws,
+            payload_dws        = payload_dws,
+            payload_be_nibbles = [0xF] * len(payload_dws),
         )
 
         # 4DW, no payload.

--- a/test/test_request_packetizer.py
+++ b/test/test_request_packetizer.py
@@ -1,0 +1,98 @@
+#
+# This file is part of LitePCIe.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import math
+import unittest
+
+from migen.sim import passive, run_simulation
+
+from litepcie.tlp.packetizer import LitePCIeTLPPacketizer
+
+
+class TestRequestPacketizer(unittest.TestCase):
+    def packetize_write(self, data_width, length):
+        dut = LitePCIeTLPPacketizer(
+            data_width    = data_width,
+            endianness    = "big",
+            address_width = 64,
+            capabilities  = ["REQUEST"],
+        )
+        beats = []
+
+        @passive
+        def monitor():
+            while True:
+                yield dut.source.ready.eq(1)
+                if (yield dut.source.valid) and (yield dut.source.ready):
+                    beats.append({
+                        "be"    : (yield dut.source.be),
+                        "first" : (yield dut.source.first),
+                        "last"  : (yield dut.source.last),
+                    })
+                yield
+
+        def stimulus():
+            sink = dut.req_sink
+            dwords_per_beat = data_width//32
+            nbeats = math.ceil(length/dwords_per_beat)
+
+            yield sink.valid.eq(0)
+            yield sink.we.eq(1)
+            yield sink.adr.eq(0x1_0000_1000)
+            yield sink.len.eq(length)
+            yield sink.req_id.eq(0x1234)
+            yield sink.tag.eq(0x5a)
+            yield
+
+            for beat in range(nbeats):
+                yield sink.dat.eq(0x12345678 << (32*(beat % dwords_per_beat)))
+                yield sink.first.eq(beat == 0)
+                yield sink.last.eq(beat == (nbeats - 1))
+                yield sink.valid.eq(1)
+                yield
+                while not (yield sink.ready):
+                    yield
+
+            yield sink.valid.eq(0)
+            for _ in range(30):
+                yield
+
+        run_simulation(dut, [stimulus(), monitor()])
+        return beats
+
+    def test_write_keep_matches_length(self):
+        for data_width in [128, 256, 512]:
+            dwords_per_beat = data_width//32
+            lengths = sorted(set([
+                1,
+                dwords_per_beat//2,
+                dwords_per_beat,
+                dwords_per_beat + dwords_per_beat//2,
+            ]))
+            for length in lengths:
+                with self.subTest(data_width=data_width, length=length):
+                    beats = self.packetize_write(data_width, length)
+                    valid_dwords = sum(
+                        1
+                        for beat in beats
+                        for lane in range(data_width//32)
+                        if ((beat["be"] >> (4*lane)) & 0xf) == 0xf
+                    )
+
+                    self.assertEqual(valid_dwords, 4 + length)
+                    self.assertEqual([beat["last"] for beat in beats].count(1), 1)
+
+    def test_512b_32byte_tail_fits_one_rq_beat(self):
+        beats = self.packetize_write(data_width=512, length=8)
+
+        self.assertEqual(len(beats), 1)
+        self.assertEqual(beats[0]["first"], 1)
+        self.assertEqual(beats[0]["last"], 1)
+        self.assertEqual(beats[0]["be"], (1 << (16 + 32)) - 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_tlp_controller.py
+++ b/test/test_tlp_controller.py
@@ -331,3 +331,60 @@ class TestTLPController(unittest.TestCase):
             observed_requests[1],
         ])
         self.assertEqual([c["end"] for c in observed_completions], [0, 1, 1])
+
+    def test_request_footprint_depth_accepts_legal_younger_completions(self):
+        data_width = 128
+        beats_needed = completion_buffer_depth(data_width)
+        controller = LitePCIeTLPController(
+            data_width           = data_width,
+            address_width        = 32,
+            max_pending_requests = 4,
+            cmp_bufs_buffered    = False,
+            cmp_buf_depth        = beats_needed,
+        )
+
+        observed_requests = []
+        accepted = []
+
+        @passive
+        def monitor_requests():
+            source = controller.master_out.sink
+            while len(observed_requests) < 3:
+                yield source.ready.eq(1)
+                if (yield source.valid) and (yield source.ready):
+                    observed_requests.append((yield source.tag))
+                yield
+
+        def stim():
+            yield
+            for index in range(3):
+                yield from self._issue_read_request(
+                    controller,
+                    index         = index,
+                    length_dwords = beats_needed * (data_width // 32),
+                )
+
+            while len(observed_requests) < 3:
+                yield
+
+            # Fill two younger tags to their exact legal footprint while the oldest request
+            # is still pending. This must not stall because each tag only needs one request's
+            # worth of buffering.
+            for tag in observed_requests[1:]:
+                accepted_for_tag = []
+                yield from self._push_completion(
+                    controller,
+                    tag      = tag,
+                    channel  = 0,
+                    user_id  = 0,
+                    beats    = beats_needed,
+                    accepted = accepted_for_tag,
+                    timeout  = beats_needed + 8,
+                )
+                accepted.extend(accepted_for_tag)
+
+            for _ in range(4):
+                yield
+
+        run_simulation(controller, [stim(), monitor_requests()], vcd_name=None)
+        self.assertEqual(len(accepted), 2 * beats_needed)

--- a/test/test_tlp_controller.py
+++ b/test/test_tlp_controller.py
@@ -9,7 +9,7 @@ import unittest
 from litex.gen import *
 
 from litepcie.tlp.common import max_request_size
-from litepcie.tlp.controller import LitePCIeTLPController
+from litepcie.tlp.controller import LitePCIeTLPController, completion_buffer_depth
 
 
 def _request_word(index):
@@ -25,6 +25,13 @@ def _completion_beats_for(data_width, request_size=max_request_size):
 
 
 class TestTLPController(unittest.TestCase):
+    def test_completion_buffer_depth_formula(self):
+        self.assertEqual(completion_buffer_depth(64),  64)
+        self.assertEqual(completion_buffer_depth(128), 32)
+        self.assertEqual(completion_buffer_depth(256), 16)
+        self.assertEqual(completion_buffer_depth(512), 8)
+        self.assertEqual(completion_buffer_depth(128, max_request_size_bytes=124), 8)
+
     def _issue_read_request(self, controller, *, index, channel=0, user_id=0, length_dwords=8):
         sink = controller.master_in.sink
         while True:
@@ -182,7 +189,7 @@ class TestTLPController(unittest.TestCase):
 
     def test_completion_buffer_depth_matches_request_footprint(self):
         data_width = 128
-        beats_needed = _completion_beats_for(data_width)
+        beats_needed = completion_buffer_depth(data_width)
 
         def accepted_beats(cmp_buf_depth):
             controller = LitePCIeTLPController(

--- a/test/test_tlp_controller.py
+++ b/test/test_tlp_controller.py
@@ -238,6 +238,76 @@ class TestTLPController(unittest.TestCase):
         self.assertEqual(accepted_beats(beats_needed), beats_needed)
         self.assertEqual(accepted_beats(beats_needed - 1), beats_needed - 1)
 
+    def test_tag_is_not_reused_before_buffered_completion_retires(self):
+        controller = LitePCIeTLPController(
+            data_width           = 128,
+            address_width        = 32,
+            max_pending_requests = 2,
+            cmp_bufs_buffered    = True,
+            cmp_buf_depth        = 2,
+        )
+
+        observed_requests = []
+
+        @passive
+        def monitor_requests():
+            source = controller.master_out.sink
+            while True:
+                yield source.ready.eq(1)
+                if (yield source.valid) and (yield source.ready):
+                    observed_requests.append((yield source.tag))
+                yield
+
+        def stim():
+            yield controller.master_in.source.ready.eq(1)
+            yield
+            yield from self._issue_read_request(controller, index=0)
+            yield from self._issue_read_request(controller, index=1)
+            while len(observed_requests) < 2:
+                yield
+
+            # Fill the younger request's reorder buffer while the older request is pending.
+            accepted = []
+            yield from self._push_completion(
+                controller,
+                tag      = observed_requests[1],
+                channel  = 0,
+                user_id  = 0,
+                beats    = 2,
+                accepted = accepted,
+            )
+            self.assertEqual(accepted, [0, 1])
+
+            # No tag is available yet: receiving a completion must not release its tag.
+            sink = controller.master_in.sink
+            for _ in range(8):
+                yield sink.valid.eq(1)
+                yield sink.first.eq(1)
+                yield sink.last.eq(1)
+                yield sink.we.eq(0)
+                yield sink.len.eq(8)
+                yield sink.adr.eq(0x1000)
+                yield
+                self.assertEqual(len(observed_requests), 2)
+            yield sink.valid.eq(0)
+
+            # Retiring the older request releases its tag and permits the third request.
+            accepted = []
+            yield from self._push_completion(
+                controller,
+                tag      = observed_requests[0],
+                channel  = 0,
+                user_id  = 0,
+                beats    = 2,
+                accepted = accepted,
+            )
+            yield from self._issue_read_request(controller, index=2)
+            while len(observed_requests) < 3:
+                yield
+            self.assertEqual(observed_requests[2], observed_requests[0])
+
+        run_simulation(controller, [stim(), monitor_requests()], vcd_name=None)
+
     def test_split_completion_packets_hold_request_order(self):
         controller = LitePCIeTLPController(
             data_width           = 128,

--- a/test/test_tlp_controller.py
+++ b/test/test_tlp_controller.py
@@ -31,6 +31,12 @@ class TestTLPController(unittest.TestCase):
         self.assertEqual(get_completion_buffer_depth(256), 17)
         self.assertEqual(get_completion_buffer_depth(512), 9)
         self.assertEqual(get_completion_buffer_depth(128, max_request_size_bytes=124), 9)
+        self.assertEqual(get_completion_buffer_depth(64,  buffered=True), 64)
+        self.assertEqual(get_completion_buffer_depth(128, buffered=True), 32)
+        self.assertEqual(get_completion_buffer_depth(256, buffered=True), 16)
+        self.assertEqual(get_completion_buffer_depth(512, buffered=True), 8)
+        self.assertEqual(get_completion_buffer_depth(
+            128, max_request_size_bytes=124, buffered=True), 8)
 
     def _issue_read_request(self, controller, *, index, channel=0, user_id=0, length_dwords=8,
         address=None):
@@ -468,13 +474,13 @@ class TestTLPController(unittest.TestCase):
         run_simulation(controller, [stim(), monitor_requests()], vcd_name=None)
         self.assertEqual(len(accepted), 2 * request_beats)
 
-    def test_completion_buffer_accounts_for_packet_boundary_rounding(self):
+    def _check_completion_buffer_accounts_for_packet_boundary_rounding(self, cmp_bufs_buffered):
         data_width = 128
         controller = LitePCIeTLPController(
             data_width           = data_width,
             address_width        = 32,
             max_pending_requests = 2,
-            cmp_bufs_buffered    = False,
+            cmp_bufs_buffered    = cmp_bufs_buffered,
         )
 
         observed_requests = []
@@ -564,3 +570,11 @@ class TestTLPController(unittest.TestCase):
             vcd_name=None,
         )
         self.assertEqual(retired_tags, observed_requests)
+
+    def test_unbuffered_completion_buffer_accounts_for_packet_boundary_rounding(self):
+        self._check_completion_buffer_accounts_for_packet_boundary_rounding(
+            cmp_bufs_buffered=False)
+
+    def test_buffered_completion_buffer_accounts_for_packet_boundary_rounding(self):
+        self._check_completion_buffer_accounts_for_packet_boundary_rounding(
+            cmp_bufs_buffered=True)

--- a/test/test_tlp_controller.py
+++ b/test/test_tlp_controller.py
@@ -9,7 +9,7 @@ import unittest
 from litex.gen import *
 
 from litepcie.tlp.common import max_request_size
-from litepcie.tlp.controller import LitePCIeTLPController, completion_buffer_depth
+from litepcie.tlp.controller import LitePCIeTLPController, get_completion_buffer_depth
 
 
 def _request_word(index):
@@ -26,11 +26,11 @@ def _completion_beats_for(data_width, request_size=max_request_size):
 
 class TestTLPController(unittest.TestCase):
     def test_completion_buffer_depth_formula(self):
-        self.assertEqual(completion_buffer_depth(64),  65)
-        self.assertEqual(completion_buffer_depth(128), 33)
-        self.assertEqual(completion_buffer_depth(256), 17)
-        self.assertEqual(completion_buffer_depth(512), 9)
-        self.assertEqual(completion_buffer_depth(128, max_request_size_bytes=124), 9)
+        self.assertEqual(get_completion_buffer_depth(64),  65)
+        self.assertEqual(get_completion_buffer_depth(128), 33)
+        self.assertEqual(get_completion_buffer_depth(256), 17)
+        self.assertEqual(get_completion_buffer_depth(512), 9)
+        self.assertEqual(get_completion_buffer_depth(128, max_request_size_bytes=124), 9)
 
     def _issue_read_request(self, controller, *, index, channel=0, user_id=0, length_dwords=8,
         address=None):
@@ -195,7 +195,7 @@ class TestTLPController(unittest.TestCase):
     def test_completion_buffer_depth_matches_request_footprint(self):
         data_width = 128
         request_beats = _completion_beats_for(data_width)
-        buffer_depth  = completion_buffer_depth(data_width)
+        buffer_depth  = get_completion_buffer_depth(data_width)
 
         def accepted_beats(cmp_buf_depth):
             controller = LitePCIeTLPController(
@@ -413,7 +413,7 @@ class TestTLPController(unittest.TestCase):
     def test_request_footprint_depth_accepts_legal_younger_completions(self):
         data_width = 128
         request_beats = _completion_beats_for(data_width)
-        buffer_depth  = completion_buffer_depth(data_width)
+        buffer_depth  = get_completion_buffer_depth(data_width)
         controller = LitePCIeTLPController(
             data_width           = data_width,
             address_width        = 32,
@@ -537,7 +537,7 @@ class TestTLPController(unittest.TestCase):
                 )
                 self.assertEqual(len(packet_accepted), packet_beats)
                 accepted.extend(packet_accepted)
-            self.assertEqual(len(accepted), completion_buffer_depth(data_width))
+            self.assertEqual(len(accepted), get_completion_buffer_depth(data_width))
 
             # Once the older request completes, both requests must retire in issue order.
             accepted = []

--- a/test/test_tlp_controller.py
+++ b/test/test_tlp_controller.py
@@ -26,21 +26,24 @@ def _completion_beats_for(data_width, request_size=max_request_size):
 
 class TestTLPController(unittest.TestCase):
     def test_completion_buffer_depth_formula(self):
-        self.assertEqual(completion_buffer_depth(64),  64)
-        self.assertEqual(completion_buffer_depth(128), 32)
-        self.assertEqual(completion_buffer_depth(256), 16)
-        self.assertEqual(completion_buffer_depth(512), 8)
-        self.assertEqual(completion_buffer_depth(128, max_request_size_bytes=124), 8)
+        self.assertEqual(completion_buffer_depth(64),  65)
+        self.assertEqual(completion_buffer_depth(128), 33)
+        self.assertEqual(completion_buffer_depth(256), 17)
+        self.assertEqual(completion_buffer_depth(512), 9)
+        self.assertEqual(completion_buffer_depth(128, max_request_size_bytes=124), 9)
 
-    def _issue_read_request(self, controller, *, index, channel=0, user_id=0, length_dwords=8):
+    def _issue_read_request(self, controller, *, index, channel=0, user_id=0, length_dwords=8,
+        address=None):
         sink = controller.master_in.sink
+        if address is None:
+            address = index * 64
         while True:
             yield sink.valid.eq(1)
             yield sink.first.eq(1)
             yield sink.last.eq(1)
             yield sink.we.eq(0)
             yield sink.req_id.eq(0x1234)
-            yield sink.adr.eq(index * 64)
+            yield sink.adr.eq(address)
             yield sink.len.eq(length_dwords)
             yield sink.dat.eq(_request_word(index))
             yield sink.channel.eq(channel)
@@ -54,15 +57,17 @@ class TestTLPController(unittest.TestCase):
         yield
 
     def _push_completion(self, controller, *, tag, channel, user_id, beats, accepted,
-        timeout=64, end_on_last=True):
+        timeout=64, end_on_last=True, length_dwords=None):
         sink = controller.master_out.source
+        if length_dwords is None:
+            length_dwords = beats * (controller.master_out.source.dat.nbits // 32)
         for beat_index in range(beats):
             waited = 0
             while True:
                 yield sink.valid.eq(1)
                 yield sink.first.eq(beat_index == 0)
                 yield sink.last.eq(beat_index == (beats - 1))
-                yield sink.len.eq(beats * (controller.master_out.source.dat.nbits // 32))
+                yield sink.len.eq(length_dwords)
                 yield sink.end.eq(1 if (end_on_last and beat_index == (beats - 1)) else 0)
                 yield sink.err.eq(0)
                 yield sink.tag.eq(tag)
@@ -189,7 +194,8 @@ class TestTLPController(unittest.TestCase):
 
     def test_completion_buffer_depth_matches_request_footprint(self):
         data_width = 128
-        beats_needed = completion_buffer_depth(data_width)
+        request_beats = _completion_beats_for(data_width)
+        buffer_depth  = completion_buffer_depth(data_width)
 
         def accepted_beats(cmp_buf_depth):
             controller = LitePCIeTLPController(
@@ -214,8 +220,10 @@ class TestTLPController(unittest.TestCase):
 
             def stim():
                 yield
-                yield from self._issue_read_request(controller, index=0, length_dwords=beats_needed * (data_width // 32))
-                yield from self._issue_read_request(controller, index=1, length_dwords=beats_needed * (data_width // 32))
+                yield from self._issue_read_request(
+                    controller, index=0, length_dwords=request_beats * (data_width // 32))
+                yield from self._issue_read_request(
+                    controller, index=1, length_dwords=request_beats * (data_width // 32))
 
                 while len(observed_requests) < 2:
                     yield
@@ -225,9 +233,9 @@ class TestTLPController(unittest.TestCase):
                     tag      = observed_requests[1],
                     channel  = 0,
                     user_id  = 0,
-                    beats    = beats_needed,
+                    beats    = request_beats,
                     accepted = accepted,
-                    timeout  = beats_needed + 8,
+                    timeout  = request_beats + 8,
                 )
                 for _ in range(4):
                     yield
@@ -235,8 +243,8 @@ class TestTLPController(unittest.TestCase):
             run_simulation(controller, [stim(), monitor_requests()], vcd_name=None)
             return len(accepted)
 
-        self.assertEqual(accepted_beats(beats_needed), beats_needed)
-        self.assertEqual(accepted_beats(beats_needed - 1), beats_needed - 1)
+        self.assertEqual(accepted_beats(buffer_depth),      request_beats)
+        self.assertEqual(accepted_beats(request_beats - 1), request_beats - 1)
 
     def test_tag_is_not_reused_before_buffered_completion_retires(self):
         controller = LitePCIeTLPController(
@@ -404,13 +412,14 @@ class TestTLPController(unittest.TestCase):
 
     def test_request_footprint_depth_accepts_legal_younger_completions(self):
         data_width = 128
-        beats_needed = completion_buffer_depth(data_width)
+        request_beats = _completion_beats_for(data_width)
+        buffer_depth  = completion_buffer_depth(data_width)
         controller = LitePCIeTLPController(
             data_width           = data_width,
             address_width        = 32,
             max_pending_requests = 4,
             cmp_bufs_buffered    = False,
-            cmp_buf_depth        = beats_needed,
+            cmp_buf_depth        = buffer_depth,
         )
 
         observed_requests = []
@@ -431,7 +440,7 @@ class TestTLPController(unittest.TestCase):
                 yield from self._issue_read_request(
                     controller,
                     index         = index,
-                    length_dwords = beats_needed * (data_width // 32),
+                    length_dwords = request_beats * (data_width // 32),
                 )
 
             while len(observed_requests) < 3:
@@ -447,9 +456,9 @@ class TestTLPController(unittest.TestCase):
                     tag      = tag,
                     channel  = 0,
                     user_id  = 0,
-                    beats    = beats_needed,
+                    beats    = request_beats,
                     accepted = accepted_for_tag,
-                    timeout  = beats_needed + 8,
+                    timeout  = request_beats + 8,
                 )
                 accepted.extend(accepted_for_tag)
 
@@ -457,4 +466,101 @@ class TestTLPController(unittest.TestCase):
                 yield
 
         run_simulation(controller, [stim(), monitor_requests()], vcd_name=None)
-        self.assertEqual(len(accepted), 2 * beats_needed)
+        self.assertEqual(len(accepted), 2 * request_beats)
+
+    def test_completion_buffer_accounts_for_packet_boundary_rounding(self):
+        data_width = 128
+        controller = LitePCIeTLPController(
+            data_width           = data_width,
+            address_width        = 32,
+            max_pending_requests = 2,
+            cmp_bufs_buffered    = False,
+        )
+
+        observed_requests = []
+        retired_tags = []
+
+        @passive
+        def monitor_requests():
+            source = controller.master_out.sink
+            while len(observed_requests) < 2:
+                yield source.ready.eq(1)
+                if (yield source.valid) and (yield source.ready):
+                    observed_requests.append((yield source.tag))
+                yield
+
+        @passive
+        def monitor_completions():
+            source = controller.master_in.source
+            while len(retired_tags) < 2:
+                yield source.ready.eq(1)
+                if ((yield source.valid) and (yield source.ready) and
+                    (yield source.last) and (yield source.end)):
+                    retired_tags.append((yield source.tag))
+                yield
+
+        def stim():
+            yield
+            yield from self._issue_read_request(
+                controller,
+                index         = 0,
+                length_dwords = 128,
+                address       = 0,
+            )
+            yield from self._issue_read_request(
+                controller,
+                index         = 1,
+                length_dwords = 128,
+                address       = 4,
+            )
+            while len(observed_requests) < 2:
+                yield
+
+            # A 512-byte request starting four bytes after a 128-byte completion boundary can be
+            # returned as 124 + 128 + 128 + 128 + 4 bytes. The independently packed Completion
+            # TLPs occupy 8 + 8 + 8 + 8 + 1 = 33 beats on a 128-bit datapath.
+            completion_sizes = [124, 128, 128, 128, 4]
+            accepted = []
+            for packet_index, completion_size in enumerate(completion_sizes):
+                packet_beats = (completion_size + data_width//8 - 1)//(data_width//8)
+                packet_accepted = []
+                yield from self._push_completion(
+                    controller,
+                    tag           = observed_requests[1],
+                    channel       = 0,
+                    user_id       = 0,
+                    beats         = packet_beats,
+                    accepted      = packet_accepted,
+                    timeout       = 8,
+                    end_on_last   = packet_index == (len(completion_sizes) - 1),
+                    length_dwords = completion_size//4,
+                )
+                self.assertEqual(len(packet_accepted), packet_beats)
+                accepted.extend(packet_accepted)
+            self.assertEqual(len(accepted), completion_buffer_depth(data_width))
+
+            # Once the older request completes, both requests must retire in issue order.
+            accepted = []
+            yield from self._push_completion(
+                controller,
+                tag      = observed_requests[0],
+                channel  = 0,
+                user_id  = 0,
+                beats    = 1,
+                accepted = accepted,
+            )
+            self.assertEqual(accepted, [0])
+
+            timeout = 0
+            while len(retired_tags) < 2:
+                timeout += 1
+                if timeout > 64:
+                    self.fail(f"Timed out waiting for completions, retired {retired_tags}")
+                yield
+
+        run_simulation(
+            controller,
+            [stim(), monitor_requests(), monitor_completions()],
+            vcd_name=None,
+        )
+        self.assertEqual(retired_tags, observed_requests)

--- a/test/test_xilinx_pciephy.py
+++ b/test/test_xilinx_pciephy.py
@@ -16,9 +16,8 @@ from litepcie.phy.usppciephy import USPPCIEPHY
 
 
 class DummyPlatform:
-    device = "xc7a35t"
-
-    def __init__(self):
+    def __init__(self, device="xc7a35t"):
+        self.device = device
         self.toolchain = SimpleNamespace(
             pre_placement_commands = [],
             pre_synthesis_commands = [],
@@ -84,7 +83,7 @@ class TestXilinxPCIEPHY(unittest.TestCase):
         self.assertIs(phy.pcie_phy_params["i_s_axis_tx_tuser"],     phy.s_axis_tx_tuser)
         self.assertEqual(len(phy.s_axis_tx_tuser), 4)
 
-    def test_s7_user_clock_matches_link_width_and_datapath(self):
+    def test_s7_clock_and_ip_config_match_link_width_and_datapath(self):
         for nlanes, pcie_data_width, user_clk_freq in [
             (1,  64, 125e6),
             (1, 128, 125e6),
@@ -94,24 +93,33 @@ class TestXilinxPCIEPHY(unittest.TestCase):
             (4, 128, 125e6),
             (8, 128, 250e6),
         ]:
-            with self.subTest(nlanes=nlanes, pcie_data_width=pcie_data_width):
-                phy = S7PCIEPHY(
-                    DummyPlatform(),
-                    DummyPads(nlanes),
-                    data_width      = pcie_data_width,
-                    pcie_data_width = pcie_data_width,
-                )
-                self.assertEqual(phy.user_clk_freq, user_clk_freq)
+            for data_width in [64, 128]:
+                with self.subTest(
+                    nlanes=nlanes,
+                    pcie_data_width=pcie_data_width,
+                    data_width=data_width,
+                ):
+                    platform = DummyPlatform(device="xc7k325t")
+                    phy = S7PCIEPHY(
+                        platform,
+                        DummyPads(nlanes),
+                        data_width      = data_width,
+                        pcie_data_width = pcie_data_width,
+                    )
+                    mmcm_config = phy.mmcm.compute_config()
+                    phy.add_sources(platform, phy_path="")
+                    tcl = "\n".join(platform.toolchain.pre_synthesis_commands)
 
-    def test_s7_generated_x4_64b_clock_configuration(self):
-        platform = DummyPlatform()
-        phy = S7PCIEPHY(platform, DummyPads(4), data_width=64, pcie_data_width=64)
-        phy.add_sources(platform, phy_path="")
-        tcl = "\n".join(platform.toolchain.pre_synthesis_commands)
-
-        self.assertIn("CONFIG.Maximum_Link_Width {{X4}}", tcl)
-        self.assertIn("CONFIG.Interface_Width {{64_bit}}", tcl)
-        self.assertIn("CONFIG.User_Clk_Freq {{250}}", tcl)
+                    self.assertEqual(phy.user_clk_freq, user_clk_freq)
+                    self.assertEqual(phy.mmcm.clkouts[3].freq, user_clk_freq)
+                    self.assertEqual(mmcm_config["clkout3_freq"], user_clk_freq)
+                    self.assertIn(f"CONFIG.Maximum_Link_Width {{{{X{nlanes}}}}}", tcl)
+                    self.assertIn(f"CONFIG.Interface_Width {{{{{pcie_data_width}_bit}}}}", tcl)
+                    self.assertIn(
+                        f"CONFIG.User_Clk_Freq {{{{{int(user_clk_freq/1e6)}}}}}",
+                        tcl,
+                    )
+                    self.assertEqual(tcl.count("synth_ip $obj"), 1)
 
     def test_s7_rejects_x8_64b_datapath(self):
         with self.assertRaisesRegex(ValueError, "Gen2 x8.*64-bit"):

--- a/test/test_xilinx_pciephy.py
+++ b/test/test_xilinx_pciephy.py
@@ -110,7 +110,7 @@ class TestXilinxPCIEPHY(unittest.TestCase):
                     phy.add_sources(platform, phy_path="")
                     tcl = "\n".join(platform.toolchain.pre_synthesis_commands)
 
-                    self.assertEqual(phy.user_clk_freq, user_clk_freq)
+                    self.assertEqual(phy.userclk_freq, user_clk_freq)
                     self.assertEqual(phy.mmcm.clkouts[3].freq, user_clk_freq)
                     self.assertEqual(mmcm_config["clkout3_freq"], user_clk_freq)
                     self.assertIn(f"CONFIG.Maximum_Link_Width {{{{X{nlanes}}}}}", tcl)

--- a/test/test_xilinx_pciephy.py
+++ b/test/test_xilinx_pciephy.py
@@ -31,6 +31,17 @@ class DummyPlatform:
         pass
 
 
+class DummyPads:
+    def __init__(self, nlanes):
+        self.rst_n = Signal()
+        self.clk_p = Signal()
+        self.clk_n = Signal()
+        self.tx_p  = Signal(nlanes)
+        self.tx_n  = Signal(nlanes)
+        self.rx_p  = Signal(nlanes)
+        self.rx_n  = Signal(nlanes)
+
+
 class TestXilinxPCIEPHY(unittest.TestCase):
     def test_bar_size_config_is_exact(self):
         self.assertEqual(get_bar_size_config(        128), ("Bytes",      128))
@@ -67,20 +78,44 @@ class TestXilinxPCIEPHY(unittest.TestCase):
                 self.assertIn("CONFIG.pf0_bar0_size {{256}}", tcl)
 
     def test_tx_ecrc_follows_aer_control(self):
-        pads = SimpleNamespace(
-            rst_n = Signal(),
-            clk_p = Signal(),
-            clk_n = Signal(),
-            tx_p  = Signal(2),
-            tx_n  = Signal(2),
-            rx_p  = Signal(2),
-            rx_n  = Signal(2),
-        )
-        phy = S7PCIEPHY(DummyPlatform(), pads, data_width=64, pcie_data_width=64)
+        phy = S7PCIEPHY(DummyPlatform(), DummyPads(2), data_width=64, pcie_data_width=64)
 
         self.assertIs(phy.pcie_phy_params["o_cfg_aer_ecrc_gen_en"], phy.cfg_aer_ecrc_gen_en)
         self.assertIs(phy.pcie_phy_params["i_s_axis_tx_tuser"],     phy.s_axis_tx_tuser)
         self.assertEqual(len(phy.s_axis_tx_tuser), 4)
+
+    def test_s7_user_clock_matches_link_width_and_datapath(self):
+        for nlanes, pcie_data_width, user_clk_freq in [
+            (1,  64, 125e6),
+            (1, 128, 125e6),
+            (2,  64, 125e6),
+            (2, 128, 125e6),
+            (4,  64, 250e6),
+            (4, 128, 125e6),
+            (8, 128, 250e6),
+        ]:
+            with self.subTest(nlanes=nlanes, pcie_data_width=pcie_data_width):
+                phy = S7PCIEPHY(
+                    DummyPlatform(),
+                    DummyPads(nlanes),
+                    data_width      = pcie_data_width,
+                    pcie_data_width = pcie_data_width,
+                )
+                self.assertEqual(phy.user_clk_freq, user_clk_freq)
+
+    def test_s7_generated_x4_64b_clock_configuration(self):
+        platform = DummyPlatform()
+        phy = S7PCIEPHY(platform, DummyPads(4), data_width=64, pcie_data_width=64)
+        phy.add_sources(platform, phy_path="")
+        tcl = "\n".join(platform.toolchain.pre_synthesis_commands)
+
+        self.assertIn("CONFIG.Maximum_Link_Width {{X4}}", tcl)
+        self.assertIn("CONFIG.Interface_Width {{64_bit}}", tcl)
+        self.assertIn("CONFIG.User_Clk_Freq {{250}}", tcl)
+
+    def test_s7_rejects_x8_64b_datapath(self):
+        with self.assertRaisesRegex(ValueError, "Gen2 x8.*64-bit"):
+            S7PCIEPHY(DummyPlatform(), DummyPads(8), data_width=64, pcie_data_width=64)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This series hardens generated S7 clocking, completion reordering, and wide-interface DMA handling.

### S7 generated PHY clocking

- Select `User_Clk_Freq` from the supported lane-count and hard-IP datapath-width combinations.
- Use the same frequency for both the LiteX MMCM output and generated Xilinx IP configuration.
- Preserve existing 128-bit behavior while making x4/64-bit configurations select the required 250 MHz user clock.
- Reject the unsupported Gen2 x8/64-bit combination instead of attempting to generate a 500 MHz user clock.

### Completion ordering and tag lifetime

- Size each per-tag completion FIFO for one maximum-size outstanding request plus one beat for completion-packet boundary rounding.
- Return a request tag only when its buffered completion retires from the ordered output.
- Prevent a younger request from reusing a tag whose previous completion still occupies the reorder FIFO, which can otherwise create a circular backpressure stall.
- Keep normal and error completions on the same ordered-retirement path.

### Partial wide-interface requests and completions

- Generate final-beat requester byte enables from the TLP length at 128-, 256-, and 512-bit widths.
- Propagate completion byte enables through the depacketizer and DMA reader.
- Flush valid payload DWORDs left behind by header removal instead of dropping the shifted packet tail.
- Add a DMA reader downconverter that discards invalid trailing subwords instead of exposing padding as application data.
- Track split-request metadata so the final valid application-width word carries the original descriptor boundary, including partial completion beats and `last_disable` handling.
- Reset width-conversion and request-metadata state when DMA is disabled.

## Why

Wide PCIe interfaces expose two related edge cases that aligned transfers do not reveal:

1. A request whose length is not a full interface beat must not advertise padding bytes as payload.
2. A completion downsized to a narrower application stream must discard invalid subwords while still terminating the DMA descriptor on its final valid word.

Completion reordering also requires tags to remain owned until ordered retirement, not merely until arrival, because an arrived completion can remain buffered behind an older request.

The completion buffer needs one additional interface beat beyond the request payload. A legal request can be split into multiple completion packets, and independently rounding each packet to the FIFO beat width can consume one more beat than rounding the complete request once.

Header removal also shifts completion payloads across PHY beats. When the final input beat still contains payload beyond the DWORDs copied into the current output beat, that tail must be emitted as an additional beat before asserting `last`.

## Verification

Full regression:

```text
pytest -q
121 passed, 83 subtests passed
```

Vivado 2024.1 KC705 Gen2 x4/64-bit implementation:

```text
PCIe User_Clk_Freq: 250 MHz
Bitstream generated successfully
WNS: +0.103 ns, TNS: 0.000 ns
250 MHz PCIe user-clock WNS: +0.296 ns
```

Coverage includes:

- Completion-buffer depth calculations across supported interface widths.
- A maximum-size request split at an unaligned completion boundary, proving that every rounded packet beat fits.
- Multiple full younger completions buffered behind an older request.
- Tag reuse only after ordered retirement.
- Request framing at 128/256/512 bits.
- Split and reordered completions.
- Shifted-tail preservation at 64/128/256/512 bits under backpressure.
- Exact Series-7-width DMA reader boundaries for partial 64- and 128-bit final beats.
- 512-bit PCIe to 256-bit DMA round trips with 32-byte descriptor tails.
- Exact DMA reader `last` positions under backpressure and mixed `last_disable` descriptors.
- Solvable MMCM settings and matching generated IP Tcl for every supported Series-7 lane/datapath combination.

## Compatibility

- Existing public DMA descriptor interfaces are unchanged.
- The completion FIFO default remains substantially smaller than the historical fixed depth while covering the complete maximum request plus packet-boundary rounding.
- Additional metadata storage is bounded by `max_pending_requests`.
- Gen2 x8 requires the 128-bit PCIe hard-IP datapath; x8/64-bit configurations now fail early with a clear error.
