### PR TITLE
phy: clean up Cyclone V and Stratix V wrappers

### DIFF
--- a/litepcie/phy/c5pciephy.py
+++ b/litepcie/phy/c5pciephy.py
@@ -4,28 +4,89 @@
 # Copyright (c) 2019 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+"""Intel Cyclone V PCIe hard IP wrapper.
+
+The PHY expects a Platform Designer system named ``pcie_phy``. The system owns the PCIe hard IP
+and its transceiver reconfiguration controller and exposes the Avalon-ST application interface
+used below.
+"""
+
 import os
 
 from migen import *
-from migen.genlib.cdc import MultiReg
 
 from litex.gen import *
 
-from litex.soc.interconnect.csr import *
-from litex.soc.interconnect.avalon import *
+from litex.soc.interconnect import stream
+from litex.soc.interconnect.avalon import Native2AvalonST, AvalonST2Native
 
 from litepcie.common import *
 
-# --------------------------------------------------------------------------------------------------
+# Configuration Space Decode -----------------------------------------------------------------------
+
+class _C5Config(LiteXModule):
+    """Decode the configuration registers exported by the Cyclone V hard IP."""
+    def __init__(self):
+        self.tl_cfg_add    = Signal(4)
+        self.tl_cfg_ctl    = Signal(32)
+        self.tl_cfg_ctl_wr = Signal()
+
+        self.id               = Signal(16, reset_less=True)
+        self.max_request_size = Signal(16, reset_less=True)
+        self.max_payload_size = Signal(16, reset_less=True)
+
+        self.bus_number      = Signal(8)
+        self.device_number   = Signal(5)
+        self.function_number = Signal(3)
+
+        # # #
+
+        def convert_size(command, size):
+            cases = {}
+            for n in range(6):
+                cases[n] = size.eq(128 << n)
+            return Case(command, cases)
+
+        dcommand     = Signal(16)
+        cfg_ctl_wr_d = Signal()
+
+        # tl_cfg_ctl_wr is a toggle, not a one-cycle pulse. Its transition announces a new stable
+        # tl_cfg_add/tl_cfg_ctl window. Detecting it directly is more robust than inferring the
+        # update from tl_cfg_add[0], as the original wrapper did.
+        self.sync += [
+            cfg_ctl_wr_d.eq(self.tl_cfg_ctl_wr),
+            If(self.tl_cfg_ctl_wr != cfg_ctl_wr_d,
+                If(self.tl_cfg_add == 0x0,
+                    dcommand.eq(self.tl_cfg_ctl[0:16]),
+                ),
+                If(self.tl_cfg_add == 0xf,
+                    self.device_number.eq(self.tl_cfg_ctl[0:5]),
+                    self.bus_number.eq(self.tl_cfg_ctl[5:13]),
+                ),
+            ),
+            convert_size(dcommand[5:8],   self.max_payload_size),
+            convert_size(dcommand[12:15], self.max_request_size),
+            self.id.eq(Cat(self.function_number, self.device_number, self.bus_number)),
+        ]
+
+        # The generated hard IP enables a single function.
+        self.comb += self.function_number.eq(0)
+
+# C5PCIEPHY ----------------------------------------------------------------------------------------
 
 class C5PCIEPHY(LiteXModule):
     endianness    = "little"
-    qword_aligned = True
+    qword_aligned = True # The Avalon-ST interface presents payloads qword-aligned.
+
     def __init__(self, platform, pads, data_width=64, cd="sys",
         # PCIe hardblock parameters.
-        bar0_size = 0x100000,
+        bar0_size    = 0x100000,
+        # Transceiver reconfiguration controller clock/reset. The clock must be free-running and
+        # meet the requirements of the generated Platform Designer system.
+        reconfig_clk = None,
+        reconfig_rst = None,
     ):
-        # Streams ---------------------------------------------------------------------------------
+        # Streams ----------------------------------------------------------------------------------
         self.sink   = stream.Endpoint(phy_layout(data_width))
         self.source = stream.Endpoint(phy_layout(data_width))
         self.msi    = stream.Endpoint(msi_layout())
@@ -34,38 +95,41 @@ class C5PCIEPHY(LiteXModule):
         self.pads             = pads
         self.platform         = platform
         self.data_width       = data_width
-
-        self.id               = Signal(16, reset_less=True)
         self.bar0_size        = bar0_size
         self.bar0_mask        = get_bar_mask(bar0_size)
-        self.max_request_size = Signal(16, reset_less=True)
-        self.max_payload_size = Signal(16, reset_less=True)
 
         self.external_hard_ip = False
 
         # # #
 
-        pcie_clk                       = Signal()
-        pcie_rst_n                     = Signal(reset=1)
-        pcie_reconfig_clk              = Signal()
-        pcie_coreclkout_hip_clk        = Signal()
-        pcie_pld_clk_clk               = Signal()
-        pcie_pld_clk_1_clk             = Signal()
+        self.nlanes = nlanes = len(pads.tx_p)
 
-        pcie_config_tl_tl_cfg_add      = Signal(4)
-        pcie_o_config_tl_tl_cfg_ctl    = Signal(32)
-        pcie_hip_rst_serdes_pll_locked = Signal()
-        pcie_o_power_mngt_pme_to_sr    = Signal()
+        # Checks -----------------------------------------------------------------------------------
+        assert nlanes in [1, 2, 4]
+        assert len(pads.rx_p) == nlanes
+        assert data_width in [64, 128]
 
-         # Clocking ---------------------------------------------------------------------------------
+        # Clocking / Reset -------------------------------------------------------------------------
+        self.cd_pcie = ClockDomain()
+
+        coreclkout_hip = Signal()
+        reset_status   = Signal()
+        self.comb += [
+            self.cd_pcie.clk.eq(coreclkout_hip),
+            self.cd_pcie.rst.eq(reset_status),
+        ]
+
+        if reconfig_clk is None:
+            reconfig_clk = ClockSignal(cd)
+        if reconfig_rst is None:
+            reconfig_rst = ResetSignal(cd)
+
         pcie_refclk = Signal()
         self.specials += Instance("ALT_INBUF_DIFF",
             i_i    = pads.clk_p,
             i_ibar = pads.clk_n,
-            o_o    = pcie_refclk
+            o_o    = pcie_refclk,
         )
-
-        self.cd_pcie = ClockDomain()
 
         # TX CDC (FPGA --> HOST) -------------------------------------------------------------------
         if cd == "pcie":
@@ -78,7 +142,7 @@ class C5PCIEPHY(LiteXModule):
             self.submodules += tx_buffer, tx_cdc
             self.comb += [
                 self.sink.connect(tx_buffer.sink),
-                tx_buffer.source.connect(tx_cdc.sink)
+                tx_buffer.source.connect(tx_cdc.sink),
             ]
             tx_st = tx_cdc.source
 
@@ -93,7 +157,7 @@ class C5PCIEPHY(LiteXModule):
             self.submodules += rx_buffer, rx_cdc
             self.comb += [
                 rx_cdc.source.connect(rx_buffer.sink),
-                rx_buffer.source.connect(self.source)
+                rx_buffer.source.connect(self.source),
             ]
             rx_st = rx_cdc.sink
 
@@ -107,153 +171,99 @@ class C5PCIEPHY(LiteXModule):
             self.comb += self.msi.connect(msi_cdc.sink)
             cfg_msi = msi_cdc.source
 
-        # Hard IP Configuration --------------------------------------------------------------------
-        def convert_size(command, size):
-            cases = {}
-            value = 128
-            for i in range(6):
-                cases[i] = size.eq(value)
-                value = value*2
-            return Case(command, cases)
+        # Configuration Space ----------------------------------------------------------------------
+        config = ClockDomainsRenamer("pcie")(_C5Config())
+        self.submodules += config
 
-        bus_number      = Signal(8)
-        device_number   = Signal(5)
-        function_number = Signal(3)
-        dcommand        = Signal(16)
+        self.id               = config.id
+        self.max_request_size = config.max_request_size
+        self.max_payload_size = config.max_payload_size
+        self.bus_number       = config.bus_number
+        self.device_number    = config.device_number
+        self.function_number  = config.function_number
 
-        self.bus_number      = bus_number
-        self.device_number   = device_number
-        self.function_number = function_number
-
-        tl_cfg_add_reg_lsb    = Signal()
-        tl_cfg_add_reg2_lsb   = Signal()
-        cfgctl_addr_change    = Signal()
-        cfgctl_addr_change2   = Signal()
-        cfgctl_addr_strobe    = Signal()
-        captured_cfg_addr_reg = Signal(4)
-        captured_cfg_data_reg = Signal(32)
-
-        self.sync.pcie += [
-            convert_size(dcommand[12:15], self.max_request_size),
-            convert_size(dcommand[5:8], self.max_payload_size),
-            self.id.eq(Cat(function_number, device_number, bus_number))
-        ]
-
-        # To capture configuration space Register, register LSB bit of tl_cfg_add
-        self.sync.pcie += [
-            tl_cfg_add_reg_lsb.eq(pcie_config_tl_tl_cfg_add[0]),
-            tl_cfg_add_reg2_lsb.eq(tl_cfg_add_reg_lsb)
-        ]
-        # Detect the address change to generate a strobe to sample the input 32-bit data
-        self.sync.pcie += [
-            cfgctl_addr_change.eq(tl_cfg_add_reg_lsb != tl_cfg_add_reg2_lsb),
-            cfgctl_addr_change2.eq(cfgctl_addr_change),
-            cfgctl_addr_strobe.eq(cfgctl_addr_change2)
-        ]
-        self.sync.pcie += [
-            captured_cfg_addr_reg.eq(pcie_config_tl_tl_cfg_add),
-            captured_cfg_data_reg.eq(pcie_o_config_tl_tl_cfg_ctl)
-        ]
-
-        # Get dcommand
-        self.sync.pcie += [
-            If((cfgctl_addr_strobe == 1) & (captured_cfg_addr_reg == 0),
-                dcommand.eq(captured_cfg_data_reg[0:16])
-            )
-        ]
-        # Get device_number and bus_number
-        self.sync.pcie += [
-            If((cfgctl_addr_strobe == 1) & (captured_cfg_addr_reg == 15),
-                device_number.eq(captured_cfg_data_reg[0:5]),
-                bus_number.eq(captured_cfg_data_reg[5:13])
-            )
-        ]
-
-        # tl_cfg_add[6:4] should represent function number whose information is being presented on
-        # tl_cfg_ctl, but only one function is enabled on IP core  in this case function_number is
-        # always 0
-        self.comb += function_number.eq(0)
-
-        # Native stream <--> AvalonST --------------------------------------------------------------
+        # Native Stream <-> Avalon-ST --------------------------------------------------------------
         tx_n2av = Native2AvalonST(phy_layout(data_width), latency=2)
         tx_n2av = ClockDomainsRenamer("pcie")(tx_n2av)
-        self.comb += tx_st.connect(tx_n2av.sink)
-        self.submodules += tx_n2av
-
         rx_av2n = AvalonST2Native(phy_layout(data_width), latency=2)
         rx_av2n = ClockDomainsRenamer("pcie")(rx_av2n)
-        self.comb += rx_av2n.source.connect(rx_st)
-        self.submodules += rx_av2n
+        self.submodules += tx_n2av, rx_av2n
+        self.comb += [
+            tx_st.connect(tx_n2av.sink),
+            rx_av2n.source.connect(rx_st),
+        ]
 
         tx_avst = tx_n2av.source
         rx_avst = rx_av2n.sink
 
         # Hard IP ----------------------------------------------------------------------------------
+        pme_to_sr         = Signal()
+        serdes_pll_locked = Signal()
+
         self.pcie_phy_params = dict(
             # Clocks
             i_refclk_clk                = pcie_refclk,
             i_pld_clk_clk               = ClockSignal("pcie"),
-            o_coreclkout_hip_clk        = ClockSignal("pcie"),
+            o_coreclkout_hip_clk        = coreclkout_hip,
 
             # Resets
             i_npor_npor                 = 1 if not hasattr(pads, "rst_n") else pads.rst_n,
             i_npor_pin_perst            = 1 if not hasattr(pads, "rst_n") else pads.rst_n,
+            o_hip_rst_reset_status      = reset_status,
 
-            # Hard IP Reconfiguration
-            i_reconfig_clk_clk          = pcie_reconfig_clk,
-            i_reconfig_reset_reset_n    = pcie_rst_n,
+            # Transceiver Reconfiguration Controller
+            i_reconfig_clk_clk          = reconfig_clk,
+            i_reconfig_reset_reset_n    = ~reconfig_rst,
 
             # Power Management
-            i_power_mngt_pme_to_cr      = pcie_o_power_mngt_pme_to_sr,
-            o_power_mngt_pme_to_sr      = pcie_o_power_mngt_pme_to_sr,
+            i_power_mngt_pme_to_cr      = pme_to_sr,
+            o_power_mngt_pme_to_sr      = pme_to_sr,
 
-            # Config (Configuration space)
-            o_config_tl_tl_cfg_ctl      = pcie_o_config_tl_tl_cfg_ctl,
-            o_config_tl_tl_cfg_add      = pcie_config_tl_tl_cfg_add,
+            # Configuration Space
+            o_config_tl_tl_cfg_ctl      = config.tl_cfg_ctl,
+            o_config_tl_tl_cfg_add      = config.tl_cfg_add,
+            o_config_tl_tl_cfg_ctl_wr   = config.tl_cfg_ctl_wr,
 
             # Control
-            o_hip_rst_serdes_pll_locked = pcie_hip_rst_serdes_pll_locked,
-            i_hip_rst_pld_core_ready    = pcie_hip_rst_serdes_pll_locked,
+            o_hip_rst_serdes_pll_locked = serdes_pll_locked,
+            i_hip_rst_pld_core_ready    = serdes_pll_locked,
 
-            # RX Port
+            # RX Avalon-ST
             o_rx_st_valid               = rx_avst.valid,
             o_rx_st_startofpacket       = rx_avst.first,
             o_rx_st_endofpacket         = rx_avst.last,
             i_rx_st_ready               = rx_avst.ready,
             o_rx_st_data                = rx_avst.dat,
 
-            # TX Port
+            # TX Avalon-ST
             i_tx_st_valid               = tx_avst.valid,
             i_tx_st_startofpacket       = tx_avst.first,
             i_tx_st_endofpacket         = tx_avst.last,
             o_tx_st_ready               = tx_avst.ready,
             i_tx_st_data                = tx_avst.dat,
 
-            # Serial IF
-            i_hip_serial_rx_in0         = pads.rx_p[0],
-            i_hip_serial_rx_in1         = pads.rx_p[1],
-            i_hip_serial_rx_in2         = pads.rx_p[2],
-            i_hip_serial_rx_in3         = pads.rx_p[3],
-            o_hip_serial_tx_out0        = pads.tx_p[0],
-            o_hip_serial_tx_out1        = pads.tx_p[1],
-            o_hip_serial_tx_out2        = pads.tx_p[2],
-            o_hip_serial_tx_out3        = pads.tx_p[3],
-
             # MSI
             i_int_msi_app_msi_num       = 0,
             i_int_msi_app_msi_req       = cfg_msi.valid,
             i_int_msi_app_msi_tc        = 0,
             o_int_msi_app_msi_ack       = cfg_msi.ready,
-            i_int_msi_app_int_sts       = 0
+            i_int_msi_app_int_sts       = 0,
         )
+
+        # Serial lanes.
+        for n in range(nlanes):
+            self.pcie_phy_params[f"i_hip_serial_rx_in{n}"]  = pads.rx_p[n]
+            self.pcie_phy_params[f"o_hip_serial_tx_out{n}"] = pads.tx_p[n]
 
     # External Hard IP -----------------------------------------------------------------------------
     def use_external_hard_ip(self, hard_ip_path):
+        qip = os.path.join(
+            hard_ip_path, "altera", "cyclone_v", "pcie_phy", "synthesis", "pcie_phy.qip")
+        self.platform.add_source(qip, "QIP")
         self.external_hard_ip = True
-        self.platform.add_source(
-            os.path.join("altera", "cyclone_v", "pcie_phy", "synthesis", "pcie_phy.qip"), "QIP")
 
+    # Finalize -------------------------------------------------------------------------------------
     def do_finalize(self):
         if not self.external_hard_ip:
-            raise ValueError("User needs to provide Hard IP source path with use_external_hard_ip")
+            raise ValueError("C5PCIEPHY requires use_external_hard_ip() with a generated Qsys IP")
         self.specials += Instance("pcie_phy", **self.pcie_phy_params)

--- a/litepcie/phy/svpciephy.py
+++ b/litepcie/phy/svpciephy.py
@@ -36,10 +36,10 @@ see https://github.com/ruurdk/sv_second_pcie_hip), `rx_st_be` (byte enables come
 and are qword-granular), `rx_st_mask`, TX parity, hard-IP reconfiguration, CvP, MSI-X and AER.
 """
 
+import hashlib
 import os
 import re
 import shutil
-import hashlib
 import subprocess
 
 from migen import *
@@ -51,7 +51,7 @@ from litex.soc.interconnect.avalon import Native2AvalonST, AvalonST2Native
 
 from litepcie.common import *
 
-# Quartus / Qsys discovery -------------------------------------------------------------------------
+# Quartus / Qsys Discovery -------------------------------------------------------------------------
 
 def _find_quartus_tool(name, quartus_bindir=None):
     """Locate a Quartus or Qsys binary.
@@ -103,11 +103,12 @@ def _find_quartus_ip_root(quartus_bindir=None):
         raise OSError(f"Quartus IP directory not found at {ip}.")
     return ip
 
-# Hard IP source files -----------------------------------------------------------------------------
+# Hard IP Sources ----------------------------------------------------------------------------------
 
 # Synthesis file list that the absent altera_pcie_sv_hip_ast_hw.tcl would have declared. The first
-# group is what `altpcie_sv_hip_ast_hwtcl` and `altpcie_hip_256_pipen1b` instantiate; the transceiver
-# groups come from Intel's `sv_xcvr_native_fileset.tcl` and `altera_xcvr_generic/ctrl/`.
+# group is what `altpcie_sv_hip_ast_hwtcl` and `altpcie_hip_256_pipen1b` instantiate; the
+# transceiver groups come from Intel's `sv_xcvr_native_fileset.tcl` and
+# `altera_xcvr_generic/ctrl/`.
 _HIP_SOURCES = {
     "altera_pcie/altera_pcie_sv_hip_ast" : [
         "altpcie_sv_hip_ast_hwtcl.v",
@@ -131,7 +132,8 @@ _HIP_SOURCES = {
     ],
     "altera_xcvr_generic/sv" : [
         "sv_pcs.sv", "sv_pcs_ch.sv", "sv_pma.sv",
-        "sv_reconfig_bundle_to_xcvr.sv", "sv_reconfig_bundle_to_ip.sv", "sv_reconfig_bundle_merger.sv",
+        "sv_reconfig_bundle_to_xcvr.sv", "sv_reconfig_bundle_to_ip.sv",
+        "sv_reconfig_bundle_merger.sv",
         "sv_rx_pma.sv", "sv_tx_pma.sv", "sv_tx_pma_ch.sv",
         "sv_xcvr_h.sv", "sv_xcvr_avmm_csr.sv", "sv_xcvr_avmm_dcd.sv", "sv_xcvr_avmm.sv",
         "sv_xcvr_data_adapter.sv", "sv_xcvr_native.sv", "sv_xcvr_plls.sv",
@@ -167,8 +169,8 @@ _HIP_SDCS = [
 def add_hip_sources(platform, quartus_bindir=None):
     ip_root = _find_quartus_ip_root(quartus_bindir)
     for subdir, files in _HIP_SOURCES.items():
-        for f in files:
-            path = os.path.join(ip_root, subdir, f)
+        for filename in files:
+            path = os.path.join(ip_root, subdir, filename)
             if not os.path.exists(path):
                 raise OSError(
                     f"Stratix V PCIe hard IP source missing: {path}\n"
@@ -178,7 +180,7 @@ def add_hip_sources(platform, quartus_bindir=None):
     for sdc in _HIP_SDCS:
         platform.add_ip(os.path.join(ip_root, sdc))
 
-# Transceiver Reconfiguration Controller generation ------------------------------------------------
+# Transceiver Reconfiguration Controller Generation ------------------------------------------------
 
 # Number of transceiver reconfiguration interfaces, per Intel's Stratix V PCIe example designs
 # (<quartus>/ip/altera/altera_pcie/altera_pcie_hip_ast_ed/example_design/sv/pcie_de_*.qsys):
@@ -234,8 +236,8 @@ def generate_xcvr_reconfig(name, device, family, ninterfaces, output_dir, quartu
     Cached on a hash of everything that affects the output, like litedram.phy.intel_uniphy.
     """
     tcl = _build_reconfig_qsys_tcl(name, device, family, ninterfaces)
-    _CACHE_VERSION = "1"
-    hash = hashlib.sha256((_CACHE_VERSION + tcl).encode()).hexdigest()[:16]
+    cache_version = "1"
+    digest = hashlib.sha256((cache_version + tcl).encode()).hexdigest()[:16]
 
     output_dir = os.path.abspath(output_dir)
     os.makedirs(output_dir, exist_ok=True)
@@ -244,8 +246,12 @@ def generate_xcvr_reconfig(name, device, family, ninterfaces, output_dir, quartu
     top        = os.path.join(output_dir, name, "synthesis", f"{name}.v")
 
     if not force and os.path.exists(qip) and os.path.exists(top) and os.path.exists(stampfile):
-        if open(stampfile).read().strip() == hash:
-            print(f"[SVPCIEPHY] Reusing cached transceiver reconfig IP in {output_dir} (hash {hash}).")
+        with open(stampfile) as f:
+            cached_digest = f.read().strip()
+        if cached_digest == digest:
+            print(
+                f"[SVPCIEPHY] Reusing cached transceiver reconfig IP in {output_dir} "
+                f"(hash {digest}).")
             return qip, top
 
     qsys_script   = _find_quartus_tool("qsys-script",   quartus_bindir)
@@ -261,10 +267,10 @@ def generate_xcvr_reconfig(name, device, family, ninterfaces, output_dir, quartu
         [qsys_generate, f"{name}.qsys", "--synthesis=VERILOG", f"--family={family}",
                         f"--part={device}"],
     ]:
-        r = subprocess.run(cmd, cwd=output_dir)
-        if r.returncode != 0:
+        result = subprocess.run(cmd, cwd=output_dir)
+        if result.returncode != 0:
             raise OSError(
-                f"[SVPCIEPHY] {os.path.basename(cmd[0])} failed (exit {r.returncode}).\n"
+                f"[SVPCIEPHY] {os.path.basename(cmd[0])} failed (exit {result.returncode}).\n"
                 f"  cmd: {' '.join(cmd)}\n  cwd: {output_dir}\n"
                 f"Rerun it by hand there to see the full Qsys log."
             )
@@ -272,7 +278,7 @@ def generate_xcvr_reconfig(name, device, family, ninterfaces, output_dir, quartu
         raise OSError(f"[SVPCIEPHY] generation reported success but {qip} is missing.")
 
     with open(stampfile, "w") as f:
-        f.write(hash)
+        f.write(digest)
     return qip, top
 
 def probe_reconfig_widths(top_verilog):
@@ -281,7 +287,9 @@ def probe_reconfig_widths(top_verilog):
     Read rather than recomputed, so a change in Intel's per-interface bus width cannot silently
     produce a mismatched instantiation.
     """
-    src = open(top_verilog).read()
+    with open(top_verilog) as f:
+        src = f.read()
+
     def width(port):
         m = re.search(r"\[\s*(\d+)\s*:\s*0\s*\]\s+" + port, src)
         if m is None:
@@ -306,7 +314,7 @@ def _int_params_to_32bit(params):
             params[k] = Constant(v, 32)
     return params
 
-# Qword alignment ----------------------------------------------------------------------------------
+# Qword Alignment ----------------------------------------------------------------------------------
 
 def _tlp_needs_pad(header_dw0, header_dw2, header_dw3):
     """Intel's qword-alignment rule, as a Migen expression.
@@ -546,32 +554,33 @@ class SVPCIEPHY(LiteXModule):
 
     def __init__(self, platform, pads, data_width=256, cd="sys",
         # Link configuration.
-        speed          = "gen2",   # "gen1" or "gen2".
-        nlanes         = 8,
-        # PCIe hard block parameters.
-        bar0_size      = 0x100000,
-        vendor_id      = 0x1172,   # Altera.
-        device_id      = 0xe001,
-        revision_id    = 0x00,   # LitePCIe's kernel driver rejects any non-zero PCI revision.
-        class_code     = 0xff0000, # Unassigned class.
+        speed            = "gen2",   # "gen1" or "gen2".
+        nlanes           = 8,
+        # PCIe hardblock parameters.
+        bar0_size        = 0x100000,
+        vendor_id        = 0x1172,   # Altera.
+        device_id        = 0xe001,
+        # LitePCIe's kernel driver rejects any non-zero PCI revision.
+        revision_id      = 0x00,
+        class_code       = 0xff0000, # Unassigned class.
         subsys_vendor_id = 0x1172,
         subsys_device_id = 0xe001,
         max_payload_size = 256,
         # Quartus release the IP is parameterised for. Only needs changing on a Quartus whose
         # Stratix V PCIe IP expects a different value; validated on 25.1std.
-        acds_version   = "25.1",
+        acds_version     = "25.1",
         # Clocking.
-        mgmt_clk       = None,     # Transceiver Reconfiguration Controller clock (see below).
-        mgmt_rst       = None,
-        mgmt_clk_name  = None,     # Its SDC clock name, if it is not `cd`'s (for timing cuts).
+        mgmt_clk         = None,     # Transceiver Reconfiguration Controller clock (see below).
+        mgmt_rst         = None,
+        mgmt_clk_name    = None,     # Its SDC clock name, if it is not `cd`'s (for timing cuts).
         # Toolchain.
-        device         = None,
-        family         = "Stratix V",
-        name           = "svpcie_xcvr_reconfig",
-        output_dir     = None,
-        quartus_bindir = None,
+        device           = None,
+        family           = "Stratix V",
+        name             = "svpcie_xcvr_reconfig",
+        output_dir       = None,
+        quartus_bindir   = None,
     ):
-        # Streams ---------------------------------------------------------------------------------
+        # Streams ----------------------------------------------------------------------------------
         self.sink   = stream.Endpoint(phy_layout(data_width))
         self.source = stream.Endpoint(phy_layout(data_width))
         self.msi    = stream.Endpoint(msi_layout())
@@ -580,7 +589,6 @@ class SVPCIEPHY(LiteXModule):
         self.pads             = pads
         self.platform         = platform
         self.data_width       = data_width
-
         self.id               = Signal(16, reset_less=True)
         self.bar0_size        = bar0_size
         self.bar0_mask        = get_bar_mask(bar0_size)
@@ -624,7 +632,7 @@ class SVPCIEPHY(LiteXModule):
 
         # # #
 
-        # Clock domains ----------------------------------------------------------------------------
+        # Clocking / Reset -------------------------------------------------------------------------
         self.cd_pcie = ClockDomain()
 
         coreclkout_hip = Signal()
@@ -642,12 +650,12 @@ class SVPCIEPHY(LiteXModule):
         if mgmt_rst is None:
             mgmt_rst = ResetSignal(cd)
 
-        # Hard IP sources --------------------------------------------------------------------------
+        # Hard IP Sources --------------------------------------------------------------------------
         add_hip_sources(platform, quartus_bindir)
 
-        # Transceiver Reconfiguration Controller ----------------------------------------------------
+        # Transceiver Reconfiguration Controller ---------------------------------------------------
         ninterfaces = reconfig_interfaces(nlanes, speed)
-        qip, top    = generate_xcvr_reconfig(
+        qip, top     = generate_xcvr_reconfig(
             name           = name,
             device         = device,
             family         = family,
@@ -660,8 +668,8 @@ class SVPCIEPHY(LiteXModule):
         # package into the generated system's own Verilog library, where the driver (which sits in
         # the default library alongside the rest of the design) cannot see it. Add the package to
         # the default library as well; a package may be declared in more than one library.
-        platform.add_source(os.path.join(os.path.dirname(qip), "submodules",
-                                         "alt_xcvr_reconfig_h.sv"))
+        platform.add_source(os.path.join(
+            os.path.dirname(qip), "submodules", "alt_xcvr_reconfig_h.sv"))
         widths = probe_reconfig_widths(top)
 
         reconfig_to_xcvr   = Signal(widths["to"])
@@ -689,7 +697,7 @@ class SVPCIEPHY(LiteXModule):
             i_reconfig_mgmt_writedata               = reconfig_mgmt_writedata,
         )
 
-        # PCIe reconfig driver ----------------------------------------------------------------------
+        # PCIe Reconfiguration Driver --------------------------------------------------------------
         # Intel's own driver for the controller above; the hard IP's status signals it watches are
         # connected as in their example design.
         currentspeed = Signal(2)
@@ -720,20 +728,20 @@ class SVPCIEPHY(LiteXModule):
                                                "gen2": "Gen2 (5.0 Gbps)"}[speed],
             p_INTENDED_DEVICE_FAMILY        = family,
 
-            i_pld_clk                 = ClockSignal("pcie"),
-            i_reconfig_xcvr_rst       = mgmt_rst,
-            i_reconfig_xcvr_clk       = mgmt_clk,
-            i_reconfig_busy           = reconfig_busy,
-            o_cal_busy_in             = Signal(),
+            i_pld_clk                   = ClockSignal("pcie"),
+            i_reconfig_xcvr_rst         = mgmt_rst,
+            i_reconfig_xcvr_clk         = mgmt_clk,
+            i_reconfig_busy             = reconfig_busy,
+            o_cal_busy_in               = Signal(),
 
-            o_reconfig_mgmt_address   = reconfig_mgmt_address,
-            o_reconfig_mgmt_read      = reconfig_mgmt_read,
-            i_reconfig_mgmt_readdata  = reconfig_mgmt_readdata,
+            o_reconfig_mgmt_address     = reconfig_mgmt_address,
+            o_reconfig_mgmt_read        = reconfig_mgmt_read,
+            i_reconfig_mgmt_readdata    = reconfig_mgmt_readdata,
             i_reconfig_mgmt_waitrequest = reconfig_mgmt_waitrequest,
-            o_reconfig_mgmt_write     = reconfig_mgmt_write,
-            o_reconfig_mgmt_writedata = reconfig_mgmt_writedata,
+            o_reconfig_mgmt_write       = reconfig_mgmt_write,
+            o_reconfig_mgmt_writedata   = reconfig_mgmt_writedata,
 
-            i_currentspeed            = currentspeed,
+            i_currentspeed              = currentspeed,
             **{f"i_{k}_drv": v for k, v in hip_status.items()},
         )
 
@@ -777,7 +785,7 @@ class SVPCIEPHY(LiteXModule):
             self.comb += self.msi.connect(msi_cdc.sink)
             cfg_msi = msi_cdc.source
 
-        # Configuration space decode ----------------------------------------------------------------
+        # Configuration Space Decode ---------------------------------------------------------------
         # tl_cfg_ctl is a 32-bit window multiplexed over 16 addresses selected by tl_cfg_add. There
         # is no write strobe on Stratix V, so the address is watched for a change and the data
         # sampled mid-window (doc 683093 s5.13.1). Field mapping is Figure 55 of the same doc.
@@ -786,10 +794,8 @@ class SVPCIEPHY(LiteXModule):
 
         def convert_size(command, size):
             cases = {}
-            value = 128
-            for i in range(6):
-                cases[i] = size.eq(value)
-                value = value*2
+            for n in range(6):
+                cases[n] = size.eq(128 << n)
             return Case(command, cases)
 
         bus_number      = Signal(8)
@@ -845,17 +851,21 @@ class SVPCIEPHY(LiteXModule):
         # Only one function is enabled on the hard IP, so the function number is always 0.
         self.comb += function_number.eq(0)
 
-        # Qword alignment + native <-> Avalon-ST --------------------------------------------------
-        tx_align = ClockDomainsRenamer("pcie")(_TXQwordAligner(data_width))
-        rx_align = ClockDomainsRenamer("pcie")(_RXQwordDealigner(data_width))
+        # Qword Alignment + Native <-> Avalon-ST ---------------------------------------------------
+        tx_align = _TXQwordAligner(data_width)
+        tx_align = ClockDomainsRenamer("pcie")(tx_align)
+        rx_align = _RXQwordDealigner(data_width)
+        rx_align = ClockDomainsRenamer("pcie")(rx_align)
         self.submodules += tx_align, rx_align
 
         # Avalon-ST readyLatency, from the Stratix V Avalon-ST PCIe user guide (Intel doc 683093):
         # the RX interface "supports a readyLatency of 3 cycles" (raised from 2 in v18.0; older
         # copies of the guide say 2, and its own figures are inconsistent, so size for 3), while for
         # TX "Intel recommends a readyLatency of 2 cycles to facilitate timing closure".
-        tx_n2av = ClockDomainsRenamer("pcie")(Native2AvalonST(phy_layout(data_width), latency=2))
-        rx_av2n = ClockDomainsRenamer("pcie")(AvalonST2Native(phy_layout(data_width), latency=3))
+        tx_n2av = Native2AvalonST(phy_layout(data_width), latency=2)
+        tx_n2av = ClockDomainsRenamer("pcie")(tx_n2av)
+        rx_av2n = AvalonST2Native(phy_layout(data_width), latency=3)
+        rx_av2n = ClockDomainsRenamer("pcie")(rx_av2n)
         self.submodules += tx_n2av, rx_av2n
 
         self.comb += [
@@ -876,7 +886,8 @@ class SVPCIEPHY(LiteXModule):
         tx_empty   = Signal(max=max(nqwords, 2))
         qword_used = Signal(nqwords)
         self.comb += [
-            [qword_used[q].eq(tx_avst.be[8*q:8*(q+1)] != 0) for q in range(nqwords)],
+            qword_used[q].eq(tx_avst.be[8*q:8*(q+1)] != 0)
+            for q in range(nqwords)
         ]
         self.comb += Case(Cat(*[qword_used[q] for q in range(nqwords)]), {
             **{(1 << (q+1))-1 : tx_empty.eq(nqwords-1-q) for q in range(nqwords)},
@@ -884,9 +895,10 @@ class SVPCIEPHY(LiteXModule):
         })
 
         # Byte enables come from rx_st_empty, not rx_st_be: the latter is deprecated and "only
-        # applies to PCI Express Memory Write and I/O Write TLP payload fields", so it reads zero for
-        # completion payloads. rx_st_empty counts unused qwords and is valid only with rx_st_eop, so
-        # an odd trailing dword shows up as valid and is discarded downstream via the length field.
+        # applies to PCI Express Memory Write and I/O Write TLP payload fields", so it reads zero
+        # for completion payloads. rx_st_empty counts unused qwords and is valid only with
+        # rx_st_eop, so an odd trailing dword shows up as valid and is discarded downstream via the
+        # length field.
         rx_empty = Signal(2)
         self.comb += [
             rx_avst.be.eq(2**(data_width//8)-1),
@@ -896,14 +908,14 @@ class SVPCIEPHY(LiteXModule):
             ),
         ]
 
-        # Hard IP -----------------------------------------------------------------------------------
+        # Hard IP ----------------------------------------------------------------------------------
         pcie_refclk = Signal()
         self.comb += pcie_refclk.eq(pads.clk_p)
 
         serdes_pll_locked = Signal()
 
         self.hip_params = dict(
-            # Link.
+            # Link
             p_lane_mask_hwtcl             = f"x{nlanes}",
             p_gen123_lane_rate_mode_hwtcl = {"gen1": "Gen1 (2.5 Gbps)",
                                              "gen2": "Gen2 (5.0 Gbps)"}[speed],
@@ -911,25 +923,25 @@ class SVPCIEPHY(LiteXModule):
             p_pcie_spec_version_hwtcl     = "2.1",
             p_pll_refclk_freq_hwtcl       = "100 MHz",
 
-            # Avalon-ST.
+            # Avalon-ST
             p_ast_width_hwtcl             = f"Avalon-ST {data_width}-bit",
             p_port_width_data_hwtcl       = data_width,
             p_port_width_be_hwtcl         = data_width//8,
             p_multiple_packets_per_cycle_hwtcl = 0,
             p_use_ast_parity              = 0,
 
-            # Reconfiguration buses.
+            # Reconfiguration Buses
             p_reconfig_to_xcvr_width      = widths["to"],
             p_reconfig_from_xcvr_width    = widths["from"],
             p_hip_reconfig_hwtcl          = 0,
 
-            # BAR0 only, 64-bit, non-prefetchable.
+            # BAR0 Only, 64-bit, Non-Prefetchable
             p_bar0_io_space_hwtcl         = "Disabled",
             p_bar0_64bit_mem_space_hwtcl  = "Enabled",
             p_bar0_prefetchable_hwtcl     = "Disabled",
             p_bar0_size_mask_hwtcl        = log2_int(bar0_size),
 
-            # Identity.
+            # Identity
             p_vendor_id_hwtcl             = vendor_id,
             p_device_id_hwtcl             = device_id,
             p_revision_id_hwtcl           = revision_id,
@@ -938,7 +950,7 @@ class SVPCIEPHY(LiteXModule):
             p_subsystem_device_id_hwtcl   = subsys_device_id,
             p_max_payload_size_hwtcl      = max_payload_size,
 
-            # MSI: one vector, no MSI-X.
+            # MSI: One Vector, No MSI-X
             p_msi_support_hwtcl           = "true",
             p_msi_multi_message_capable_hwtcl = "count_1",
             p_msi_64bit_addressing_capable_hwtcl = "true",
@@ -952,12 +964,12 @@ class SVPCIEPHY(LiteXModule):
 
             p_ACDS_VERSION_HWTCL          = acds_version,
 
-            # Clocks.
+            # Clocks
             i_refclk                      = pcie_refclk,
             i_pld_clk                     = ClockSignal("pcie"),
             o_coreclkout_hip              = coreclkout_hip,
 
-            # Resets / status.
+            # Resets / Status
             i_npor                        = ~ResetSignal(cd) & pads.perst_n,
             i_pin_perst                   = pads.perst_n,
             o_reset_status                = reset_status,
@@ -975,22 +987,22 @@ class SVPCIEPHY(LiteXModule):
             i_sim_pipe_pclk_in            = 0,
             i_hpg_ctrler                  = 0,
 
-            # Transceiver reconfiguration.
+            # Transceiver Reconfiguration
             i_reconfig_to_xcvr            = reconfig_to_xcvr,
             o_reconfig_from_xcvr          = reconfig_from_xcvr,
 
-            # Config space.
+            # Configuration Space
             o_tl_cfg_add                  = tl_cfg_add,
             o_tl_cfg_ctl                  = tl_cfg_ctl,
 
-            # Status (to the reconfig driver).
+            # Status (to the Reconfiguration Driver)
             o_currentspeed                = currentspeed,
             **{f"o_{k}": v for k, v in hip_status.items()},
 
         )
 
         self.hip_params.update(
-            # RX Avalon-ST.
+            # RX Avalon-ST
             o_rx_st_valid                 = rx_avst.valid,
             o_rx_st_sop                   = rx_avst.first,
             o_rx_st_eop                   = rx_avst.last,
@@ -999,7 +1011,7 @@ class SVPCIEPHY(LiteXModule):
             o_rx_st_empty                 = rx_empty,
             i_rx_st_mask                  = 0,
 
-            # TX Avalon-ST.
+            # TX Avalon-ST
             i_tx_st_valid                 = tx_avst.valid,
             i_tx_st_sop                   = tx_avst.first,
             i_tx_st_eop                   = tx_avst.last,
@@ -1009,23 +1021,23 @@ class SVPCIEPHY(LiteXModule):
             i_tx_st_err                   = 0,
             i_tx_st_parity                = 0,
 
-            # Completion / error reporting: unused.
+            # Completion / Error Reporting: Unused
             i_cpl_err                     = 0,
             i_cpl_pending                 = 0,
 
-            # Local Management Interface: unused.
+            # Local Management Interface: Unused
             i_lmi_addr                    = 0,
             i_lmi_din                     = 0,
             i_lmi_rden                    = 0,
             i_lmi_wren                    = 0,
 
-            # Power management: unused.
+            # Power Management: Unused
             i_pm_auxpwr                   = 0,
             i_pm_data                     = 0,
             i_pme_to_cr                   = 0,
             i_pm_event                    = 0,
 
-            # MSI.
+            # MSI
             i_app_msi_req                 = cfg_msi.valid,
             o_app_msi_ack                 = cfg_msi.ready,
             i_app_msi_num                 = 0,
@@ -1034,10 +1046,10 @@ class SVPCIEPHY(LiteXModule):
             i_pex_msi_num                 = 0,
             i_app_int_sts                 = 0,
 
-            # Credit / config bypass: unused.
+            # Credit / Configuration Bypass: Unused
             i_tx_cons_cred_sel            = 0,
 
-            # Hard IP reconfiguration (DPRIO): unused.
+            # Hard IP Reconfiguration (DPRIO): Unused
             i_hip_reconfig_rst_n          = 0,
             i_hip_reconfig_clk            = 0,
             i_hip_reconfig_write          = 0,
@@ -1049,23 +1061,26 @@ class SVPCIEPHY(LiteXModule):
             i_interface_sel               = 0,
         )
 
-        # Serial lanes.
+        # Serial Lanes
         for i in range(nlanes):
             self.hip_params[f"i_rx_in{i}"]  = pads.rx_p[i]
             self.hip_params[f"o_tx_out{i}"] = pads.tx_p[i]
 
-        # Constraints -------------------------------------------------------------------------------
+        # Constraints ------------------------------------------------------------------------------
         # coreclkout_hip comes from the hard IP's own PLL and is unrelated to the SoC clocks; every
         # crossing here is through an async FIFO or a MultiReg. `derive_pll_clocks` names it after
         # its hierarchy position, so LiteX's `add_false_path_constraints()` emits
-        # `set_false_path -from [get_clocks {pcie_clk}]`, which matches nothing. Hence the wildcards.
+        # `set_false_path -from [get_clocks {pcie_clk}]`, which matches nothing. Hence the
+        # wildcards.
         # Only the application clock is cut: the transceiver reconfiguration bundle carries the
         # management clock into the transceivers' AVMM blocks and those transfers are synchronous.
         pcie_core_clk = "*|coreclkout_hip"
         for name in [f"{cd}_clk"] + ([mgmt_clk_name] if mgmt_clk_name is not None else []):
             platform.toolchain.additional_sdc_commands += [
-                f"set_false_path -from [get_clocks {{{name}}}] -to [get_clocks {{{pcie_core_clk}}}]",
-                f"set_false_path -from [get_clocks {{{pcie_core_clk}}}] -to [get_clocks {{{name}}}]",
+                f"set_false_path -from [get_clocks {{{name}}}] "
+                f"-to [get_clocks {{{pcie_core_clk}}}]",
+                f"set_false_path -from [get_clocks {{{pcie_core_clk}}}] "
+                f"-to [get_clocks {{{name}}}]",
             ]
 
         # The reconfiguration controller's own SDC ends with a loop that makes each transceiver
@@ -1084,8 +1099,9 @@ class SVPCIEPHY(LiteXModule):
 
         # Constrain the 100 MHz PCIe reference clock at the pin, otherwise the transceiver PLL has
         # no base clock and `coreclkout_hip` is unconstrained. Intel's example SDC uses
-        # `derive_pll_clocks -create_base_clocks`; LiteX emits `-use_net_name`, and derive_pll_clocks
-        # must only be applied once per project, so the base clock is declared here instead.
+        # `derive_pll_clocks -create_base_clocks`; LiteX emits `-use_net_name`, and
+        # derive_pll_clocks must only be applied once per project, so the base clock is declared
+        # here instead.
         platform.add_period_constraint(pads.clk_p, 1e9/100e6)
 
         # Timing analysis of transceiver-derived clocks is meaningless without this, and Quartus
@@ -1094,5 +1110,7 @@ class SVPCIEPHY(LiteXModule):
         if "derive_clock_uncertainty" not in platform.toolchain.additional_sdc_commands:
             platform.toolchain.additional_sdc_commands.append("derive_clock_uncertainty")
 
+    # Finalize -------------------------------------------------------------------------------------
     def do_finalize(self):
-        self.specials += Instance("altpcie_sv_hip_ast_hwtcl", **_int_params_to_32bit(self.hip_params))
+        self.specials += Instance(
+            "altpcie_sv_hip_ast_hwtcl", **_int_params_to_32bit(self.hip_params))

--- a/test/test_c5pciephy.py
+++ b/test/test_c5pciephy.py
@@ -1,0 +1,93 @@
+#
+# This file is part of LitePCIe.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import unittest
+
+from migen import Signal
+from migen.sim import run_simulation
+
+from litepcie.phy.c5pciephy import C5PCIEPHY, _C5Config
+
+# Helpers ------------------------------------------------------------------------------------------
+
+class DummyPlatform:
+    def __init__(self):
+        self.sources = []
+
+    def add_source(self, filename, language=None):
+        self.sources.append((filename, language))
+
+
+class DummyPads:
+    def __init__(self, nlanes=4):
+        self.clk_p = Signal()
+        self.clk_n = Signal()
+        self.rst_n = Signal()
+        self.rx_p  = Signal(nlanes)
+        self.tx_p  = Signal(nlanes)
+
+# Tests --------------------------------------------------------------------------------------------
+
+class TestC5PCIEPHY(unittest.TestCase):
+    def test_config_toggle_decode(self):
+        dut = _C5Config()
+
+        def generator():
+            # Device Control: Max Payload = 512 bytes, Max Read Request = 1024 bytes.
+            dcommand = (2 << 5) | (3 << 12)
+            yield dut.tl_cfg_add.eq(0x0)
+            yield dut.tl_cfg_ctl.eq(dcommand)
+            yield dut.tl_cfg_ctl_wr.eq(1)
+            for _ in range(3):
+                yield
+            self.assertEqual((yield dut.max_payload_size), 512)
+            self.assertEqual((yield dut.max_request_size), 1024)
+
+            # Holding the toggle steady must not recapture changing bus contents.
+            yield dut.tl_cfg_ctl.eq(0)
+            for _ in range(3):
+                yield
+            self.assertEqual((yield dut.max_payload_size), 512)
+            self.assertEqual((yield dut.max_request_size), 1024)
+
+            # The next toggle carries the bus/device register.
+            bus_number    = 0x5a
+            device_number = 0x12
+            yield dut.tl_cfg_add.eq(0xf)
+            yield dut.tl_cfg_ctl.eq((bus_number << 5) | device_number)
+            yield dut.tl_cfg_ctl_wr.eq(0)
+            for _ in range(3):
+                yield
+            self.assertEqual((yield dut.bus_number), bus_number)
+            self.assertEqual((yield dut.device_number), device_number)
+            self.assertEqual((yield dut.id), (bus_number << 8) | (device_number << 3))
+
+        run_simulation(dut, generator())
+
+    def test_external_hard_ip_path(self):
+        platform = DummyPlatform()
+        phy      = C5PCIEPHY(platform, DummyPads())
+        phy.use_external_hard_ip("/tmp/c5-ip")
+
+        qip = os.path.join(
+            "/tmp/c5-ip", "altera", "cyclone_v", "pcie_phy", "synthesis", "pcie_phy.qip")
+        self.assertEqual(platform.sources, [(qip, "QIP")])
+        self.assertTrue(phy.external_hard_ip)
+
+    def test_generated_wrapper_ports(self):
+        phy    = C5PCIEPHY(DummyPlatform(), DummyPads(nlanes=2))
+        params = phy.pcie_phy_params
+
+        self.assertIn("o_config_tl_tl_cfg_ctl_wr", params)
+        self.assertIn("o_hip_rst_reset_status", params)
+        self.assertIn("i_hip_serial_rx_in0", params)
+        self.assertIn("i_hip_serial_rx_in1", params)
+        self.assertNotIn("i_hip_serial_rx_in2", params)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_svpciephy.py
+++ b/test/test_svpciephy.py
@@ -19,7 +19,8 @@ for Avalon-ST 256-Bit Interface") and in Intel's own example-design RTL
 import random
 import unittest
 
-from migen import *
+from migen import Module
+from migen.sim import run_simulation
 
 from litepcie.phy.svpciephy import _TXQwordAligner, _RXQwordDealigner
 
@@ -40,8 +41,8 @@ def dwords_to_beats(dwords, dws_per_beat):
     beats = []
     for i in range(0, len(dwords), dws_per_beat):
         chunk = dwords[i:i+dws_per_beat]
-        dat = 0
-        be  = 0
+        dat   = 0
+        be    = 0
         for j, d in enumerate(chunk):
             dat |= (d & 0xffffffff) << (32*j)
             be  |= 0xf << (4*j)
@@ -137,8 +138,8 @@ class TestSVPCIEPHYAlignment(unittest.TestCase):
 
     def test_tx_aligner_matches_intel_layout(self):
         for data_width in [128, 256]:
-            dws = data_width//32
-            cases = self._packets(dws)
+            dws    = data_width//32
+            cases  = self._packets(dws)
             packed = [h + p for (h, p) in cases]
             dut    = _TXQwordAligner(data_width)
             beats  = stream_packets(dut, packed, dws)


### PR DESCRIPTION
## Summary

- modernize and document the Cyclone V hard-IP wrapper
- decode Cyclone V configuration updates from the hard IP `tl_cfg_ctl_wr` toggle
- drive the Cyclone V PCIe domain reset and transceiver reconfiguration clock/reset
- honor the external hard-IP path and derive serial ports from the lane count
- add focused Cyclone V tests for configuration decoding, QIP resolution, and generated ports
- align the Cyclone V and Stratix V wrappers/tests with LiteX/LitePCIe coding style

The Avalon-ST latencies and existing qword-alignment contracts are unchanged. The Stratix V pass
only cleans structure, naming, resource handling, and formatting; its generated interfaces and
timing constraints are unchanged.

## Validation

- `pytest -q test/test_c5pciephy.py test/test_svpciephy.py` (6 passed)
- `pytest -q` (114 tests and 55 subtests passed)
- x4/64-bit Migen elaboration against the existing LimeSDR-QPCIe QIP path
- `git diff --check`
- 100-column source/ruler audit

## Notes

The legacy LimeSDR-QPCIe generator reaches PHY construction but later stops on its unrelated,
removed LiteX `add_wb_master` API, so it could not be used for a complete project regeneration.
Quartus and hardware validation have not been run for this cleanup.
