### PR TITLE
frontend/dma: retire Reader descriptors once read data is delivered

### DIFF
--- a/litepcie/frontend/dma.py
+++ b/litepcie/frontend/dma.py
@@ -260,6 +260,12 @@ class LitePCIeDMADescriptorSplitter(LiteXModule):
         self.source = source = stream.Endpoint(descriptor_layout(address_width=address_width, with_user_id=True))
 
         self.terminate = Signal() # Early Termination.
+        # When asserted, the splitter parks in WAIT-DONE after issuing the final
+        # split request and only pops the descriptor (retiring it in the table,
+        # updating loop_status and generating the IRQ) once deasserted. The Reader
+        # connects this to (pending_words != 0) so that a descriptor is only retired
+        # once all its read data has been delivered.
+        self.block_retire = Signal()
 
         # # #
 
@@ -310,13 +316,20 @@ class LitePCIeDMADescriptorSplitter(LiteXModule):
                 ),
                 # On last or terminate...
                 If(source.last | self.terminate,
-                    # Accept Descriptor.
-                    sink.ready.eq(1),
-                    # Increment User-ID.
-                    NextValue(source.user_id, source.user_id + 1),
-                    # Return to IDLE..
-                    NextState("IDLE")
+                    # Park before retiring: only pop the descriptor when the
+                    # owner (Reader) confirms in-flight data has drained.
+                    NextState("WAIT-DONE")
                 )
+            )
+        )
+        fsm.act("WAIT-DONE",
+            If(~self.block_retire,
+                # Accept Descriptor.
+                sink.ready.eq(1),
+                # Increment User-ID.
+                NextValue(source.user_id, source.user_id + 1),
+                # Return to IDLE..
+                NextState("IDLE")
             )
         )
         self.comb += length_next.eq(length - max_size) # Outside of FSM for timings.
@@ -458,6 +471,11 @@ class LitePCIeDMAReader(LiteXModule):
         # Update Pending words.
         self.sync += pending_words.eq(pending_words + pending_words_queue - pending_words_dequeue)
         self.sync += If(~enable, pending_words.eq(0))
+        # Expose pending words for observability/testability.
+        self.pending_words = pending_words
+        # Retire a descriptor only when all its read data has been delivered: retire
+        # the descriptor in the table (loop_status/IRQ) once no data is pending.
+        self.comb += splitter.block_retire.eq(pending_words != 0)
 
         # FSM --------------------------------------------------------------------------------------
         self.fsm = fsm = FSM(reset_state="IDLE")

--- a/test/test_dma_reader_retire.py
+++ b/test/test_dma_reader_retire.py
@@ -1,0 +1,152 @@
+#
+# This file is part of LitePCIe.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Regression test for the DMA Reader descriptor-retirement semantics:
+# loop_status (and the per-descriptor IRQ) must only advance once all the
+# descriptor's read data has been delivered, not when the last read request
+# is issued. Software that polls loop_status to recycle host TX buffers
+# must not be able to race the device's own outstanding reads.
+#
+# The test programs descriptors in PROG mode, monitors the pending-words
+# counter at each descriptor pop, and rewrites the host buffer the cycle
+# loop_status reports done. With correct retirement semantics, no delivered
+# data can carry the rewrite marker.
+
+import unittest
+
+import pytest
+
+from litex.gen import *
+
+from litepcie.common     import *
+from litepcie.core       import LitePCIeEndpoint
+from litepcie.core.msi   import LitePCIeMSI
+from litepcie.frontend.dma import LitePCIeDMAReader
+
+from test.common import seed_to_data
+from test.model.host import *
+
+root_id     = 0x100
+endpoint_id = 0x400
+
+
+@pytest.mark.slow
+class TestDMAReaderRetire(unittest.TestCase):
+    def test_descriptor_retired_only_when_data_delivered(self):
+        data_width     = 64
+        address_width  = 32
+        desc_count     = 4
+        desc_length    = 1024
+        total_length   = desc_count * desc_length
+
+        original  = [seed_to_data(i, True) for i in range(total_length // 4)]
+        rewritten = [0xdeadbeef] * (total_length // 4)
+        delivered = []
+
+        pops   = []   # pending_words sampled at each descriptor pop
+        beats  = 0
+        beats_expected = total_length // (data_width // 8)
+
+        def main_generator(dut):
+            dut.host.malloc(0x00000000, total_length * 2)
+            dut.host.chipset.enable()
+            dut.host.write_mem(0x00000000, original)
+
+            # Program descriptors in PROG mode.
+            yield from dut.dma_reader.table.loop_prog_n.write(0)
+            yield from dut.dma_reader.table.reset.write(1)
+            for i in range(desc_count):
+                value = (i * desc_length) & 0xffffffff
+                value |= (desc_length << 32)
+                yield from dut.dma_reader.table.value.write(value)
+                yield from dut.dma_reader.table.we.write(0)
+
+            yield from dut.dma_reader._enable.write(1)
+
+            # Software model: poll loop_status; the cycle it reports all
+            # descriptors executed, rewrite the host buffer.
+            timeout = 0
+            while True:
+                index = (yield dut.dma_reader.table.loop_status.fields.index)
+                if index >= desc_count:
+                    break
+                timeout += 1
+                if timeout > 20000:
+                    self.fail("loop_status never reached expected index")
+                yield
+            yield
+            dut.host.write_mem(0x00000000, rewritten)
+
+            # Drain until all beats delivered.
+            t2 = 0
+            while beats < beats_expected and t2 < 100000:
+                t2 += 1
+                yield
+
+        @passive
+        def pop_monitor(dut):
+            while True:
+                valid = (yield dut.dma_reader.table.source.valid)
+                ready = (yield dut.dma_reader.table.source.ready)
+                if valid and ready:
+                    pops.append((yield dut.dma_reader.pending_words))
+                yield
+
+        @passive
+        def drain(dut):
+            nonlocal beats
+            while True:
+                yield dut.dma_reader.source.ready.eq(1)
+                if (yield dut.dma_reader.source.valid):
+                    beats += 1
+                    delivered.append((yield dut.dma_reader.source.data))
+                yield
+
+        class DUT(LiteXModule):
+            def __init__(self):
+                self.host = Host(data_width, root_id, endpoint_id,
+                    phy_debug=False, chipset_debug=False,
+                    chipset_split=True, chipset_reordering=True,
+                    host_debug=False)
+                self.endpoint = LitePCIeEndpoint(self.host.phy,
+                    address_width=address_width, max_pending_requests=8)
+                port = self.endpoint.crossbar.get_master_port(read_only=True)
+                self.dma_reader = LitePCIeDMAReader(self.endpoint, port,
+                    address_width=address_width)
+                self.msi = LitePCIeMSI(1)
+                self.comb += self.msi.irqs[0].eq(self.dma_reader.irq)
+
+        dut = DUT()
+        generators = {
+            "sys": [
+                main_generator(dut),
+                drain(dut),
+                pop_monitor(dut),
+                dut.host.generator(),
+                dut.host.chipset.generator(),
+                dut.host.phy.phy_sink.generator(),
+                dut.host.phy.phy_source.generator(),
+            ]
+        }
+        from migen.sim import run_simulation
+        run_simulation(dut, generators, {"sys": 10})
+
+        self.assertEqual(beats, beats_expected, "DMA did not deliver all data")
+
+        # A descriptor must only be retired (popped -> loop_status/IRQ) once
+        # no read data is pending for it.
+        for n, pending in enumerate(pops):
+            self.assertEqual(pending, 0,
+                f"descriptor {n} retired with {pending} read words still pending")
+
+        # No delivered word may carry the post-done rewrite marker.
+        got = []
+        for d in delivered:
+            got.append(d & 0xffffffff)
+            got.append((d >> 32) & 0xffffffff)
+        torn = [w for w in got if w == 0xDEADBEEF]
+        self.assertEqual(torn, [],
+            f"{len(torn)} delivered words fetched after loop_status reported done")


### PR DESCRIPTION

### The problem

`loop_status` and the per-descriptor IRQ currently advance when a descriptor
is popped from the table — which for the Reader happens when the **last
split read request is issued** (`MEM-RD-REQ`: `port.source.ready` →
`splitter.source.ready` → splitter pops its sink). Read completions for
earlier splits — up to `max_pending_requests` — and the final request's own
data can still be outstanding at that point.

The ScatterGather docstring documents loop_status as the synchronization
mechanism for software ("safer for the software to just use the hardware
loop status than to maintain a software loop status based MSI IRQ
reception"), so drivers recycle host TX buffers on it. A driver that
rewrites a buffer once loop_status reports the descriptor done can race the
device's own outstanding reads and tear the DMA stream.

This is related to #120 but distinct: that issue was attributed to the
removed `BufferizeEndpoints` buffering the last split descriptor. The
window here is structural — it exists with no buffering, because the pop
event itself is request-issue rather than data delivery.

Simulation numbers (4x1024-byte descriptors, prog mode, 64-bit, max pending
8, host model with chipset reordering):
- descriptors retire with 64/192/317/438 read words still pending
- loop_status reports done ~730-850 cycles before the last data beat
- rewriting the host buffer right after "done" delivers rewritten data to
  the user stream

### The fix

`LitePCIeDMADescriptorSplitter` gains a `block_retire` input and a
`WAIT-DONE` state: after issuing the final split request, the splitter
parks and only pops the descriptor (retiring it in the table, updating
loop_status, generating the IRQ) once the owner deasserts `block_retire`.
The Reader connects `block_retire = (pending_words != 0)`, so "done" now
means all read data delivered. The Reader's `pending_words` counter is
exposed for observability.

Trade-off: the Reader loses inter-descriptor lookahead while a descriptor
drains (the next descriptor's first request waits for the previous
descriptor's data). An alternative that avoids the bubble would track
retirement per-descriptor through the existing `request_metadata` FIFO
(retire when the descriptor_last entry drains) — happy to rework in that
direction if preferred.

Note on the Writer: its descriptors retire when the last posted-write beat
is accepted by the port, which is the right semantics for posted writes on
the request side; the residual host-side ordering question (a Completion
for a loop_status CSR read passing a posted Memory Write in the fabric) is
 PCIe-ordering territory and out of scope here.

### Testing

`test/test_dma_reader_retire.py`: programs descriptors in prog mode,
samples `pending_words` at each descriptor pop, and rewrites the host
buffer the cycle loop_status reports done. Asserts every pop happens at
zero pending words and that no delivered word carries the post-done
rewrite marker. Fails on the previous semantics (`descriptor 0 retired
with 128 read words still pending`), passes with this change. Full
`test_dma.py` suite also passes with the change.