### PR TITLE
frontend/dma: retire Reader descriptors on final completion

### DIFF
--- a/litepcie/frontend/dma.py
+++ b/litepcie/frontend/dma.py
@@ -138,7 +138,7 @@ class LitePCIeDMAScatterGather(LiteXModule):
     potentially be lost, it's safer for the software to just use the hardware loop status than to
     maintain a software loop status based MSI IRQ reception).
     """
-    def __init__(self, depth, address_width=32):
+    def __init__(self, depth, address_width=32, with_external_retire=False):
         assert address_width in [32, 64]
         # Stream Endpoint.
         self.source = source = stream.Endpoint(descriptor_layout(address_width=address_width))
@@ -207,6 +207,19 @@ class LitePCIeDMAScatterGather(LiteXModule):
         # Table Read logic -------------------------------------------------------------------------
         self.comb += table.source.connect(source)
 
+        # Descriptor Retirement --------------------------------------------------------------------
+        # By default a descriptor retires when consumed from the table. The DMA Reader overrides
+        # this with its ordered completion path and the mode/loop marker captured at issue time, so
+        # software-visible status only advances once the corresponding Host read has completed.
+        if with_external_retire:
+            self.retire       = retire       = Signal()
+            self.retire_first = retire_first = Signal()
+            self.retire_loop  = retire_loop  = Signal()
+        else:
+            retire       = table.source.valid & table.source.ready
+            retire_first = table.source.first
+            retire_loop  = loop_mode
+
         # Loop Status (For Software Sychronization in Loop mode) -----------------------------------
         loop_first = Signal()
         loop_index = self.loop_status.fields.index
@@ -217,11 +230,11 @@ class LitePCIeDMAScatterGather(LiteXModule):
                 loop_first.eq(1),
                 loop_index.eq(0),
                 loop_count.eq(0),
-            # When a Descriptor is consumned...
-            ).Elif(table.source.valid & table.source.ready,
+            # When a Descriptor is retired...
+            ).Elif(retire,
                 # Update Loop Status with current Loop Index/Count.
                 # Loop Mode.
-                If(loop_mode & table.source.first,
+                If(retire_loop & retire_first,
                     # Reset Index.
                     loop_index.eq(0),
                     # Increment Count (except on first since we want (index, count) == (0,0)).
@@ -361,7 +374,10 @@ class LitePCIeDMAReader(LiteXModule):
 
         # Table ------------------------------------------------------------------------------------
         if with_table:
-            self.table = LitePCIeDMAScatterGather(table_depth, address_width=address_width)
+            self.table = LitePCIeDMAScatterGather(table_depth,
+                address_width        = address_width,
+                with_external_retire = True,
+            )
         else:
             self.desc_sink = stream.Endpoint(descriptor_layout(address_width=address_width)) # Expose a Descriptor sink.
 
@@ -380,10 +396,16 @@ class LitePCIeDMAReader(LiteXModule):
 
         # Request Metadata -------------------------------------------------------------------------
         # Completion TLPs are retired in request order, but last only delimits an individual
-        # Completion packet. Keep one entry per split request to delimit the original DMA
-        # descriptor on the final request's last Completion.
+        # Completion packet. Keep one entry per split request to delimit and retire the original
+        # DMA descriptor on the final request's last Completion.
         self.request_metadata = request_metadata = ResetInserter()(SyncFIFO(
-            layout   = [("descriptor_last", 1), ("last_disable", 1)],
+            layout   = [
+                ("descriptor_last", 1),
+                ("loop_first",      1),
+                ("loop_mode",       1),
+                ("irq_disable",     1),
+                ("last_disable",    1),
+            ],
             depth    = endpoint.max_pending_requests,
             buffered = True,
         ))
@@ -466,8 +488,13 @@ class LitePCIeDMAReader(LiteXModule):
                 fsm.ongoing("MEM-RD-REQ") & port.source.valid & port.source.ready
             ),
             request_metadata.sink.descriptor_last.eq(splitter.source.last),
+            request_metadata.sink.loop_first.eq(splitter.sink.first),
+            request_metadata.sink.irq_disable.eq(splitter.source.irq_disable),
             request_metadata.sink.last_disable.eq(splitter.source.last_disable),
         ]
+        self.comb += request_metadata.sink.loop_mode.eq(
+            self.table.loop_prog_n.storage if with_table else 0
+        )
         fsm.act("IDLE",
             # Reset Splitter/FIFO when disabled.
             If(~enable,
@@ -505,9 +532,24 @@ class LitePCIeDMAReader(LiteXModule):
             )
         )
 
-        # IRQ --------------------------------------------------------------------------------------
-        self.comb += If(splitter.source.valid & splitter.source.ready & splitter.source.last,
-            self.irq.eq(~splitter.source.irq_disable)
+        # Descriptor Retirement / IRQ ---------------------------------------------------------------
+        # Completions are delivered by the controller in request order. Retire the original DMA
+        # descriptor with its final split request, once the final Completion has been accepted into
+        # the Reader. At this point the Host buffer is safe for software to recycle, independently
+        # of any downstream backpressure on the Reader's output.
+        descriptor_retire = Signal()
+        self.comb += descriptor_retire.eq(
+            request_metadata.source.valid & request_metadata.source.ready &
+            request_metadata.source.descriptor_last
+        )
+        if with_table:
+            self.comb += [
+                self.table.retire.eq(descriptor_retire),
+                self.table.retire_first.eq(request_metadata.source.loop_first),
+                self.table.retire_loop.eq(request_metadata.source.loop_mode),
+            ]
+        self.comb += If(descriptor_retire,
+            self.irq.eq(~request_metadata.source.irq_disable)
         )
 
         # Progress ---------------------------------------------------------------------------------

--- a/test/test_dma_reader_retire.py
+++ b/test/test_dma_reader_retire.py
@@ -1,0 +1,177 @@
+#
+# This file is part of LitePCIe.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+import unittest
+
+import pytest
+
+from litex.gen import *
+
+from litepcie.core         import LitePCIeEndpoint
+from litepcie.frontend.dma import LitePCIeDMAReader, LitePCIeDMAScatterGather
+
+from test.common     import seed_to_data
+from test.model.host import Host
+
+
+root_id     = 0x100
+endpoint_id = 0x400
+
+
+@pytest.mark.slow
+class TestDMAReaderRetire(unittest.TestCase):
+    def test_external_retire_preserves_loop_markers(self):
+        table = LitePCIeDMAScatterGather(depth=4, with_external_retire=True)
+
+        def generator():
+            yield from table.loop_prog_n.write(0)
+            yield from table.reset.write(1)
+            for i in range(2):
+                yield from table.value.write((64 << 32) | (i * 64))
+                yield from table.we.write(0)
+            yield from table.loop_prog_n.write(1)
+
+            # Consume into the next loop before retiring anything. This verifies that table
+            # lookahead/refill is independent from ordered software-visible retirement.
+            descriptor_first = []
+            for _ in range(3):
+                while not (yield table.source.valid):
+                    yield
+                descriptor_first.append((yield table.source.first))
+                yield table.source.ready.eq(1)
+                yield
+                yield table.source.ready.eq(0)
+                yield
+            self.assertEqual(descriptor_first, [1, 0, 1])
+
+            statuses = []
+            for first in descriptor_first:
+                yield table.retire_first.eq(first)
+                yield table.retire_loop.eq(1)
+                yield table.retire.eq(1)
+                yield
+                yield table.retire.eq(0)
+                yield
+                statuses.append((
+                    (yield table.loop_status.fields.index),
+                    (yield table.loop_status.fields.count),
+                ))
+            self.assertEqual(statuses, [(0, 0), (1, 0), (0, 1)])
+
+        run_simulation(table, generator())
+
+    def test_descriptor_retires_on_final_completion(self):
+        data_width    = 64
+        address_width = 32
+        desc_count    = 4
+        desc_length   = 1024
+        total_length  = desc_count * desc_length
+        host_data     = [seed_to_data(i, True) for i in range(total_length // 4)]
+        expected      = [int.from_bytes(data.to_bytes(4, "little"), "big") for data in host_data]
+        rewritten     = [0xdeadbeef] * (total_length // 4)
+        delivered     = []
+
+        beats_expected = total_length // (data_width // 8)
+        retire_irqs    = []
+        release_output = False
+
+        class DUT(LiteXModule):
+            def __init__(self):
+                self.host = Host(data_width, root_id, endpoint_id,
+                    phy_debug          = False,
+                    chipset_debug      = False,
+                    chipset_split      = True,
+                    chipset_reordering = True,
+                    host_debug         = False,
+                )
+                self.endpoint = LitePCIeEndpoint(self.host.phy,
+                    address_width        = address_width,
+                    max_pending_requests = 8,
+                )
+                port = self.endpoint.crossbar.get_master_port(read_only=True)
+                self.reader = LitePCIeDMAReader(self.endpoint, port,
+                    address_width=address_width)
+
+        dut = DUT()
+
+        def main_generator():
+            nonlocal release_output
+
+            dut.host.malloc(0x00000000, total_length * 2)
+            dut.host.chipset.enable()
+            dut.host.write_mem(0x00000000, host_data)
+
+            yield from dut.reader.table.loop_prog_n.write(0)
+            yield from dut.reader.table.reset.write(1)
+            for i in range(desc_count):
+                value  = (i * desc_length) & 0xffffffff
+                value |= desc_length << 32
+                value |= (i == 1) << 56  # Disable IRQ on the second descriptor.
+                yield from dut.reader.table.value.write(value)
+                yield from dut.reader.table.we.write(0)
+
+            yield from dut.reader._enable.write(1)
+
+            # Keep the user stream stalled. Retirement must wait for the final PCIe Completion,
+            # but must not wait for already-fetched data to leave the Reader's internal FIFO.
+            timeout = 0
+            while (yield dut.reader.table.loop_status.fields.index) < desc_count:
+                timeout += 1
+                if timeout > 20000:
+                    self.fail("loop_status did not retire all descriptors")
+                yield
+
+            self.assertEqual((yield dut.reader.request_metadata.level), 0)
+            self.assertGreater((yield dut.reader.data_fifo.level), 0)
+
+            # Recycling the Host buffers at the documented software-visible completion point must
+            # not affect data which has already been fetched into the Reader.
+            dut.host.write_mem(0x00000000, rewritten)
+            release_output = True
+
+            timeout = 0
+            while len(delivered) < beats_expected:
+                timeout += 1
+                if timeout > 20000:
+                    self.fail("Reader output did not drain")
+                yield
+
+        @passive
+        def output_generator():
+            while True:
+                yield dut.reader.source.ready.eq(release_output)
+                if (yield dut.reader.source.valid) and (yield dut.reader.source.ready):
+                    delivered.append((yield dut.reader.source.data))
+                yield
+
+        @passive
+        def retire_monitor():
+            while True:
+                if (yield dut.reader.table.retire):
+                    retire_irqs.append((yield dut.reader.irq))
+                if (yield dut.reader.irq):
+                    self.assertEqual((yield dut.reader.table.retire), 1)
+                yield
+
+        generators = {"sys": [
+            main_generator(),
+            output_generator(),
+            retire_monitor(),
+            dut.host.generator(),
+            dut.host.chipset.generator(),
+            dut.host.phy.phy_sink.generator(),
+            dut.host.phy.phy_source.generator(),
+        ]}
+        run_simulation(dut, generators, {"sys": 10})
+
+        self.assertEqual(retire_irqs, [1, 0, 1, 1])
+        self.assertEqual(len(delivered), beats_expected)
+        received = []
+        for data in delivered:
+            received.append(data & 0xffffffff)
+            received.append((data >> 32) & 0xffffffff)
+        self.assertEqual(received, expected)


### PR DESCRIPTION
## Problem

The DMA Reader currently consumes a descriptor, advances `loop_status`, and generates its IRQ when the final split Memory Read request is issued.

At that point, Completions for that request and earlier outstanding requests can still be pending. Software following `loop_status` can therefore recycle or rewrite the Host buffer while LitePCIe is still fetching it, producing a torn Reader stream.

## Fix

Decouple descriptor-table consumption from software-visible retirement:

- Keep consuming/refilling the descriptor table at request issue time, preserving inter-descriptor lookahead.
- Carry the descriptor's loop marker, issue-time mode, and IRQ policy through the existing ordered request-metadata FIFO.
- Retire the descriptor when the final split request's final Completion is accepted by the Reader.
- Advance `loop_status` and generate the descriptor IRQ from that same retirement event.

This makes the Host buffer safe to recycle without waiting for already-fetched data to drain through the Reader output. The Writer path and CSR layout are unchanged.

## Tests

- Added a regression test that stalls the Reader output, waits for completion-based `loop_status`, rewrites the Host buffers, and verifies that the buffered stream remains intact.
- Verify IRQ timing and `irq_disable` at the retirement event.
- Verify Loop-mode index/count ordering while table consumption runs ahead of retirement.
- Full relevant DMA suite: 21 tests and 2 subtests passed.
- Final focused retirement tests: 2 passed.
- DMA status tests: 6 passed.
- A deterministic 4 x 1 KiB simulation completes in the same 849 cycles as current `master`.

This is an alternative implementation for the issue described in #176, without serializing Reader descriptors on downstream FIFO drain.
