### PR TITLE
phy: preserve RX data and byte enables across unequal widths

### DIFF
--- a/litepcie/phy/common.py
+++ b/litepcie/phy/common.py
@@ -124,7 +124,7 @@ class PHYRXDatapath(Module):
         if (clock_domain == "pcie") and (core_data_width == pcie_data_width):
             self.comb += sink.connect(source)
         else:
-            pipe_ready = stream.PipeReady(phy_layout(core_data_width))
+            pipe_ready = stream.PipeReady(phy_layout(pcie_data_width))
             pipe_ready = ClockDomainsRenamer("pcie")(pipe_ready)
             converter  = stream.StrideConverter(phy_layout(pcie_data_width), phy_layout(core_data_width))
             converter  = ClockDomainsRenamer("pcie")(converter)
@@ -138,10 +138,29 @@ class PHYRXDatapath(Module):
             pipe_valid = stream.PipeValid(phy_layout(core_data_width))
             pipe_valid = ClockDomainsRenamer(clock_domain)(pipe_valid)
             self.submodules += pipe_ready, converter, cdc, pipe_valid
+            converted = converter.source
+            if core_data_width > pcie_data_width:
+                # StrideConverter retains unused upper slices on a partial up-conversion.
+                # Track the number of loaded slices so stale byte enables cannot revive them.
+                ratio = core_data_width // pcie_data_width
+                count = Signal(max=ratio)
+                valid_slices = Signal(max=ratio + 1)
+                self.sync.pcie += If(converter.sink.valid & converter.sink.ready,
+                    If(converter.sink.last | (count == ratio - 1),
+                        valid_slices.eq(count + 1),
+                        count.eq(0),
+                    ).Else(count.eq(count + 1))
+                )
+                converted = stream.Endpoint(phy_layout(core_data_width))
+                self.comb += converter.source.connect(converted, omit={"be"})
+                for i in range(ratio):
+                    low, high = i * (pcie_data_width // 8), (i + 1) * (pcie_data_width // 8)
+                    self.comb += converted.be[low:high].eq(
+                        Mux(valid_slices > i, converter.source.be[low:high], 0))
             self.comb += [
                 sink.connect(pipe_ready.sink),
                 pipe_ready.source.connect(converter.sink),
-                converter.source.connect(cdc.sink),
+                converted.connect(cdc.sink),
                 cdc.source.connect(pipe_valid.sink),
                 pipe_valid.source.connect(source),
             ]

--- a/test/test_phy_rx_widths.py
+++ b/test/test_phy_rx_widths.py
@@ -1,0 +1,71 @@
+import random
+
+import pytest
+from migen import ClockDomain
+from migen.sim import passive, run_simulation
+from litex.soc.interconnect.stream import ClockDomainCrossing
+
+from litepcie.phy.common import PHYRXDatapath
+
+
+@pytest.mark.parametrize("phy_width", [128, 256, 512])
+@pytest.mark.parametrize("core_width", [128, 256, 512])
+def test_rx_width_conversion(phy_width, core_width):
+    dut = PHYRXDatapath(core_width, phy_width, "sys")
+    dut.clock_domains.cd_sys = ClockDomain("sys")
+    dut.clock_domains.cd_pcie = ClockDomain("pcie")
+    cdc = next(module for _, module in dut._submodules if isinstance(module, ClockDomainCrossing))
+    packets = [[0xAB000000 + length * 256 + i for i in range(length)]
+               for length in [1, 3, 4, 7, 8, 15, 16, 17, 31, 32, 33, 128]]
+    received = []
+
+    def stimulus():
+        rng = random.Random(19)
+        lanes = phy_width // 32
+        for packet in packets:
+            for offset in range(0, len(packet), lanes):
+                chunk = packet[offset:offset + lanes]
+                yield dut.sink.valid.eq(0)
+                for _ in range(rng.randrange(3)):
+                    yield
+                yield dut.sink.dat.eq(sum(word << (32 * lane) for lane, word in enumerate(chunk)))
+                yield dut.sink.be.eq((1 << (4 * len(chunk))) - 1)
+                yield dut.sink.first.eq(offset == 0)
+                yield dut.sink.last.eq(offset + lanes >= len(packet))
+                yield dut.sink.valid.eq(1)
+                yield
+                while not (yield dut.sink.ready):
+                    yield
+        yield dut.sink.valid.eq(0)
+        for _ in range(200):
+            yield
+
+    @passive
+    def monitor():
+        rng = random.Random(25)
+        packet = []
+        while True:
+            if (yield dut.source.valid) and (yield dut.source.ready):
+                data = (yield dut.source.dat)
+                be = (yield dut.source.be)
+                assert bool((yield dut.source.first)) == (not packet)
+                packet.extend((data >> (32 * lane)) & 0xffffffff for lane in range(core_width // 32)
+                              if be & (15 << (4 * lane)))
+                if (yield dut.source.last):
+                    received.append(packet)
+                    packet = []
+            yield dut.source.ready.eq(rng.randrange(3) != 0)
+            yield
+
+    @passive
+    def watchdog():
+        for _ in range(10000):
+            yield
+        raise AssertionError("RX converter stalled")
+
+    # Migen needs explicit schedules for the common-reset CDC's clock aliases.
+    run_simulation(dut, {"pcie": [stimulus(), watchdog()], "sys": monitor()}, clocks={
+        "pcie": (10, 3), "sys": 14,
+        f"from{cdc.duid}": (10, 3), f"to{cdc.duid}": 14,
+    })
+    assert received == packets


### PR DESCRIPTION
## Problem

`PHYRXDatapath` constructs its PCIe-domain input register stage at the core
width, even though it receives the PHY-width stream. A wider PHY feeding a
narrower core therefore loses data before width conversion. In the opposite
direction, a partial final up-conversion can expose stale byte enables from
unused slices of the previous output word.

## Change

- Size the input register stage for `pcie_data_width`.
- Track the slices actually loaded by an up-conversion and zero byte enables
  in unused slices before crossing to the core clock domain.
- Keep the equal-width path unchanged.

## Validation

The regression exercises all nine combinations of 128/256/512-bit PHY and
core widths, partial packets, independent clocks, input gaps and output
backpressure. It checks byte-enabled data and packet boundaries.

- Before this fix, the 256-bit PHY to 128-bit core case truncates a seven-DWORD
  packet to four DWORDs.
- All nine width combinations pass with the fix.
- Full simulation suite excluding toolchain example builds: 134 tests and
  83 subtests passed.

No board-specific configuration or generated artifacts are included.
