### PR TITLE
phy/usp: optionally buffer complete requester packets after CDC

### DIFF
--- a/litepcie/phy/common.py
+++ b/litepcie/phy/common.py
@@ -7,7 +7,10 @@
 from migen import *
 from migen.genlib.cdc import MultiReg
 
+from litex.soc.interconnect.packet import PacketFIFO
+
 from litepcie.common import *
+from litepcie.tlp.common import max_payload_size
 
 # Helpers ------------------------------------------------------------------------------------------
 
@@ -31,11 +34,22 @@ def get_bar_size_config(size):
 # TX Datapath --------------------------------------------------------------------------------------
 
 class PHYTXDatapath(Module):
-    def __init__(self, core_data_width, pcie_data_width, clock_domain):
+    def __init__(self, core_data_width, pcie_data_width, clock_domain, with_packet_buffer=False):
         self.sink   = sink   = stream.Endpoint(phy_layout(core_data_width))
         self.source = source = stream.Endpoint(phy_layout(pcie_data_width))
 
         # # #
+
+        if with_packet_buffer:
+            # Continuous input packets can acquire bubbles crossing independent
+            # clocks. Do not expose a TLP to the hard IP until its last beat has
+            # arrived in the PCIe domain (PG213 requester TVALID requirement).
+            packet_words = (max_payload_size + 16 + pcie_data_width//8 - 1)//(pcie_data_width//8)
+            self.submodules.packet_buffer = ClockDomainsRenamer("pcie")(PacketFIFO(
+                phy_layout(pcie_data_width), payload_depth=2*packet_words,
+                param_depth=4, buffered=True))
+            self.comb += self.packet_buffer.source.connect(source)
+            source = self.packet_buffer.sink
 
         if (clock_domain == "pcie") and (core_data_width == pcie_data_width):
             self.comb += sink.connect(source)

--- a/litepcie/phy/usppciephy.py
+++ b/litepcie/phy/usppciephy.py
@@ -32,6 +32,7 @@ class USPPCIEPHY(LiteXModule):
         bar0_size       = 0x100000,
         mode            = "Endpoint",
         with_cfg_mgmt   = False,
+        with_rq_buffer  = False,
     ):
         # Streams ----------------------------------------------------------------------------------
         self.req_sink   = stream.Endpoint(phy_layout(data_width))
@@ -148,7 +149,8 @@ class USPPCIEPHY(LiteXModule):
         self.rq_datapath = PHYTXDatapath(
             core_data_width = data_width,
             pcie_data_width = pcie_data_width,
-            clock_domain    = cd)
+            clock_domain    = cd,
+            with_packet_buffer = with_rq_buffer)
         self.comb += self.req_sink.connect(self.rq_datapath.sink)
         s_axis_rq = self.rq_datapath.source
 

--- a/test/test_phy_tx_packet_buffer.py
+++ b/test/test_phy_tx_packet_buffer.py
@@ -8,6 +8,50 @@ from litepcie.phy.common import PHYTXDatapath
 
 
 class TestPHYTXPacketBuffer(unittest.TestCase):
+    def test_same_domain_path_still_waits_for_complete_packet(self):
+        dut = Module()
+        dut.clock_domains.cd_pcie = ClockDomain("pcie")
+        dut.submodules.path = path = PHYTXDatapath(512, 512, "pcie", with_packet_buffer=True)
+        self.assertFalse(any(isinstance(module, ClockDomainCrossing) for _, module in path._submodules))
+        received = []
+        expected = [(i, 0xffffffffffffffff if i != 8 else 0xffff, int(i == 0), int(i == 8))
+                    for i in range(9)]
+
+        def source():
+            for data, be, first, last in expected:
+                yield path.sink.valid.eq(0)
+                for _ in range(3):
+                    yield
+                yield path.sink.dat.eq(data)
+                yield path.sink.be.eq(be)
+                yield path.sink.first.eq(first)
+                yield path.sink.last.eq(last)
+                yield path.sink.valid.eq(1)
+                yield
+                while not (yield path.sink.ready):
+                    yield
+            yield path.sink.valid.eq(0)
+            for _ in range(30):
+                yield
+
+        @passive
+        def monitor():
+            active = False
+            yield path.source.ready.eq(1)
+            while True:
+                valid = (yield path.source.valid)
+                if active:
+                    self.assertTrue(valid)
+                if valid and (yield path.source.ready):
+                    word = ((yield path.source.dat), (yield path.source.be),
+                            (yield path.source.first), (yield path.source.last))
+                    received.append(word)
+                    active = not word[3]
+                yield
+
+        run_simulation(dut, {"pcie": [source(), monitor()]}, clocks={"pcie": 10})
+        self.assertEqual(received, expected)
+
     def test_complete_packets_cross_independent_clocks(self):
         for width in (128, 256, 512):
             for ready_always in (False, True):

--- a/test/test_phy_tx_packet_buffer.py
+++ b/test/test_phy_tx_packet_buffer.py
@@ -1,0 +1,71 @@
+import random
+import unittest
+
+from migen import ClockDomain, Module
+from migen.sim import passive, run_simulation
+from litex.soc.interconnect.stream import ClockDomainCrossing
+from litepcie.phy.common import PHYTXDatapath
+
+
+class TestPHYTXPacketBuffer(unittest.TestCase):
+    def test_complete_packets_cross_independent_clocks(self):
+        for width in (128, 256, 512):
+            for ready_always in (False, True):
+                with self.subTest(width=width, ready_always=ready_always):
+                    dut = Module()
+                    dut.clock_domains.cd_sys = ClockDomain("sys")
+                    dut.clock_domains.cd_pcie = ClockDomain("pcie")
+                    dut.submodules.path = path = PHYTXDatapath(width, width, "sys", with_packet_buffer=True)
+                    lengths = [1, 3, (512+16+width//8-1)//(width//8)]*2
+                    expected, received = [], []
+                    for packet, length in enumerate(lengths):
+                        for beat in range(length):
+                            expected.append((packet*1000+beat, (1 << (width//8))-1,
+                                             int(beat == 0), int(beat == length-1)))
+
+                    def source():
+                        rng = random.Random(213)
+                        for data, be, first, last in expected:
+                            yield path.sink.valid.eq(0)
+                            for _ in range(rng.randrange(4)):
+                                yield
+                            yield path.sink.dat.eq(data)
+                            yield path.sink.be.eq(be)
+                            yield path.sink.first.eq(first)
+                            yield path.sink.last.eq(last)
+                            yield path.sink.valid.eq(1)
+                            yield
+                            while not (yield path.sink.ready):
+                                yield
+                        yield path.sink.valid.eq(0)
+                        for _ in range(4000):
+                            if len(received) == len(expected):
+                                return
+                            yield
+                        self.fail("packet buffer did not drain")
+
+                    @passive
+                    def monitor():
+                        rng = random.Random(512)
+                        active, stalled = False, None
+                        while True:
+                            valid, ready = (yield path.source.valid), (yield path.source.ready)
+                            word = ((yield path.source.dat), (yield path.source.be),
+                                    (yield path.source.first), (yield path.source.last))
+                            if active or stalled is not None:
+                                self.assertTrue(valid, "TVALID gap within a complete packet")
+                            if stalled is not None:
+                                self.assertEqual(word, stalled)
+                            stalled = word if valid and not ready else None
+                            if valid and ready:
+                                received.append(word)
+                                active = not word[3]
+                            yield path.source.ready.eq(1 if ready_always else rng.randrange(4) != 0)
+                            yield
+
+                    cdc = next(module for _, module in path._submodules
+                               if isinstance(module, ClockDomainCrossing))
+                    clocks = {"sys": 14, "pcie": (10, 3),
+                              f"from{cdc.duid}": 14, f"to{cdc.duid}": (10, 3)}
+                    run_simulation(dut, {"sys": source(), "pcie": monitor()}, clocks=clocks)
+                    self.assertEqual(received, expected)


### PR DESCRIPTION
## Problem

An ordinary stream clock crossing does not guarantee an uninterrupted
packet at its output. When the PCIe user clock consumes data faster than
the source supplies it, `TVALID` can drop after the first accepted request
beat. This violates the AMD requester interface requirement even though
each side of the FIFO follows normal ready/valid stream rules.

AMD documents that requester `TVALID` must stay asserted through the packet:
https://docs.amd.com/r/en-US/pg213-pcie4-ultrascale-plus/Requester-Memory-Write-Operation

## Change

- Add optional complete-packet buffering to `PHYTXDatapath`, after clock
  crossing and width conversion in the PCIe user clock domain.
- Expose it as `USPPCIEPHY(..., with_rq_buffer=True)` for the requester path.
- Use the existing LiteX `PacketFIFO`, sized for two maximum-size payloads
  including headers. A packet is exposed only after its final beat arrives.
- Keep the default disabled and leave completion paths and generated hard-IP
  settings unchanged, allowing targets to opt in explicitly.

## Validation

- Packet-buffer tests cover 128/256/512-bit equal-width streams, independent
  clocks, source gaps, always-ready and backpressured sinks, payload/byte-enable
  preservation, and continuous/stable output throughout accepted packets.
- An additional test covers the same-clock path without a CDC and a partial
  final beat. The expanded buffer suite passes two tests and six subtests.
- Full simulation suite excluding toolchain example builds passes 126 tests
  and 89 subtests before the extra same-clock test was added; no RTL changed
  for that additional test.

The added continuity tests use equal input/output widths. This PR does not
claim to fix or qualify all existing width-conversion behavior, link training,
or platform-specific PCIe error causes. No board-specific code or captures
are included.
