### PR TITLE
software/kernel: preserve composite DMA mapping metadata

### DIFF
--- a/litepcie/software/kernel/main.c
+++ b/litepcie/software/kernel/main.c
@@ -683,6 +683,13 @@ static int litepcie_mmap(struct file *file, struct vm_area_struct *vma)
 	if (!litepcie_enter(s))
 		return -ENODEV;
 
+	/* The ring is fixed-size device memory, not expandable or dumpable RAM. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+	vm_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
+#else
+	vma->vm_flags |= VM_DONTEXPAND | VM_DONTDUMP;
+#endif
+
 	for (i = 0; i < DMA_BUFFER_COUNT; i++) {
 #if defined(__arm__) || defined(__aarch64__)
 		void *va;
@@ -720,6 +727,14 @@ static int litepcie_mmap(struct file *file, struct vm_area_struct *vma)
 
 		ret = dma_mmap_coherent(&s->dev->dev, &sub_vma,
 					cpu_addr, dma_handle, DMA_BUFFER_SIZE);
+		/* DMA backends add PFNMAP or MIXEDMAP and may change protection.
+		 * Retain that metadata on the real VMA, including partial failure. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+		vm_flags_set(vma, sub_vma.vm_flags);
+#else
+		vma->vm_flags |= sub_vma.vm_flags;
+#endif
+		vma->vm_page_prot = sub_vma.vm_page_prot;
 		if (ret) {
 			dev_err(&s->dev->dev,
 				"dma_mmap_coherent failed for buffer %d (ret=%d)\n", i, ret);

--- a/test/kernel_mmap_mock.c
+++ b/test/kernel_mmap_mock.c
@@ -1,0 +1,115 @@
+/* Compile the actual driver mmap function against a narrow DMA API mock. */
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#define KERNEL_VERSION(a, b, c) (((a) << 16) | ((b) << 8) | (c))
+#define DMA_BUFFER_SIZE 8192UL
+#define DMA_BUFFER_COUNT 4
+#define DMA_BUFFER_TOTAL_SIZE (DMA_BUFFER_SIZE * DMA_BUFFER_COUNT)
+#define PAGE_SHIFT 12
+#define VM_IO 1UL
+#define VM_PFNMAP 2UL
+#define VM_MIXEDMAP 4UL
+#define VM_DONTEXPAND 8UL
+#define VM_DONTDUMP 16UL
+#define ORIGINAL_FLAGS 0x100UL
+#define dev_err(...) ((void)0)
+
+typedef unsigned long dma_addr_t;
+struct device { int unused; };
+struct pci_dev { struct device dev; };
+struct litepcie_device { struct pci_dev *dev; };
+struct litepcie_chan {
+    struct litepcie_device *litepcie_dev;
+    struct {
+        void *reader_addr[DMA_BUFFER_COUNT], *writer_addr[DMA_BUFFER_COUNT];
+        dma_addr_t reader_handle[DMA_BUFFER_COUNT], writer_handle[DMA_BUFFER_COUNT];
+    } dma;
+};
+struct litepcie_chan_priv { struct litepcie_chan *chan; };
+struct file { void *private_data; };
+struct vm_area_struct {
+    unsigned long vm_start, vm_end, vm_pgoff, vm_flags, vm_page_prot;
+};
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+static inline void vm_flags_set(struct vm_area_struct *vma, unsigned long flags)
+{
+    vma->vm_flags |= flags;
+}
+#endif
+
+/* Also allow the current upstream function's removal guard. */
+#define litepcie_enter(s) ((void)(s), true)
+#define litepcie_exit(s) ((void)(s))
+static int calls, fail_at, direction;
+static unsigned long mapping_flags;
+static struct vm_area_struct *parent;
+static struct litepcie_chan *channel;
+
+static int dma_mmap_coherent(struct device *dev, struct vm_area_struct *vma,
+                            void *cpu_addr, dma_addr_t handle, unsigned long size)
+{
+    (void)dev;
+    assert(size == DMA_BUFFER_SIZE);
+    assert((parent->vm_flags & (VM_DONTEXPAND | VM_DONTDUMP)) == (VM_DONTEXPAND | VM_DONTDUMP));
+    assert(vma->vm_start == parent->vm_start + calls * DMA_BUFFER_SIZE);
+    assert(vma->vm_end == vma->vm_start + DMA_BUFFER_SIZE);
+    assert(vma->vm_pgoff == 0);
+    assert(cpu_addr == (direction ? channel->dma.reader_addr[calls] : channel->dma.writer_addr[calls]));
+    assert(handle == (direction ? channel->dma.reader_handle[calls] : channel->dma.writer_handle[calls]));
+    vma->vm_flags |= mapping_flags;
+    vma->vm_page_prot = 0x77;
+    /* Even a failed mapping may have installed some PTEs. */
+    return calls++ == fail_at ? -EAGAIN : 0;
+}
+
+/* DRIVER_MMAP */
+
+int main(void)
+{
+    struct pci_dev pci = {0};
+    struct litepcie_device device = {.dev=&pci};
+    struct litepcie_chan chan = {.litepcie_dev=&device};
+    struct litepcie_chan_priv priv = {.chan=&chan};
+    struct file file = {.private_data=&priv};
+    for (int i = 0; i < DMA_BUFFER_COUNT; i++) {
+        chan.dma.reader_addr[i] = (void *)(uintptr_t)(0x100000 + i * DMA_BUFFER_SIZE);
+        chan.dma.writer_addr[i] = (void *)(uintptr_t)(0x200000 + i * DMA_BUFFER_SIZE);
+        chan.dma.reader_handle[i] = 0x300000 + i * DMA_BUFFER_SIZE;
+        chan.dma.writer_handle[i] = 0x400000 + i * DMA_BUFFER_SIZE;
+    }
+    channel = &chan;
+    struct vm_area_struct invalid = {.vm_start=0x1000000,
+        .vm_end=0x1000000 + DMA_BUFFER_TOTAL_SIZE - 1, .vm_flags=ORIGINAL_FLAGS};
+    calls = 0;
+    assert(litepcie_mmap(&file, &invalid) == -EINVAL && calls == 0);
+    invalid.vm_end++;
+    invalid.vm_pgoff = 1;
+    assert(litepcie_mmap(&file, &invalid) == -EINVAL && calls == 0);
+    for (int kind = 0; kind < 2; kind++) {
+        mapping_flags = kind ? VM_MIXEDMAP : VM_IO | VM_PFNMAP | VM_DONTEXPAND | VM_DONTDUMP;
+        for (direction = 0; direction < 2; direction++) {
+            for (fail_at = -1; fail_at < DMA_BUFFER_COUNT; fail_at++) {
+                struct vm_area_struct vma = {.vm_start=0x1000000,
+                    .vm_end=0x1000000 + DMA_BUFFER_TOTAL_SIZE,
+                    .vm_pgoff=direction ? 0 : DMA_BUFFER_TOTAL_SIZE >> PAGE_SHIFT,
+                    .vm_flags=ORIGINAL_FLAGS, .vm_page_prot=0x33};
+                struct vm_area_struct before = vma;
+                parent = &vma;
+                calls = 0;
+                assert(litepcie_mmap(&file, &vma) == (fail_at < 0 ? 0 : -EAGAIN));
+                assert(calls == (fail_at < 0 ? DMA_BUFFER_COUNT : fail_at + 1));
+                assert(vma.vm_start == before.vm_start && vma.vm_end == before.vm_end);
+                assert(vma.vm_pgoff == before.vm_pgoff);
+                assert(vma.vm_flags == (ORIGINAL_FLAGS | mapping_flags | VM_DONTEXPAND | VM_DONTDUMP));
+                assert(vma.vm_page_prot == 0x77);
+            }
+        }
+    }
+    return 0;
+}

--- a/test/test_kernel_mmap.py
+++ b/test/test_kernel_mmap.py
@@ -1,0 +1,33 @@
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+class TestKernelMmap(unittest.TestCase):
+    def test_composite_mapping_metadata(self):
+        cc = shutil.which(os.environ.get("CC", "cc"))
+        if cc is None:
+            self.skipTest("C compiler unavailable")
+        source = (Path(__file__).parents[1] / "litepcie/software/kernel/main.c").read_text()
+        function = source.split("static int litepcie_mmap(", 1)[1].split(
+            "static unsigned int litepcie_poll(", 1)[0]
+        function = "static int litepcie_mmap(" + function
+        fixture = Path(__file__).with_name("kernel_mmap_mock.c").read_text()
+        with tempfile.TemporaryDirectory() as directory:
+            c_file = Path(directory) / "mmap.c"
+            c_file.write_text(fixture.replace("/* DRIVER_MMAP */", function))
+            for version in (0x050F00, 0x060500):
+                with self.subTest(kernel_version=hex(version)):
+                    executable = Path(directory) / "mmap-test"
+                    subprocess.run([cc, "-std=c11", "-Wall", "-Wextra", "-Werror",
+                        f"-DLINUX_VERSION_CODE={version}", str(c_file), "-o", str(executable)],
+                        check=True, capture_output=True, text=True)
+                    result = subprocess.run([str(executable)], capture_output=True, text=True)
+                    self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The non-ARM composite DMA mmap path passes a temporary `sub_vma` to
`dma_mmap_coherent()` for each buffer, then discards the metadata changes.
Depending on the DMA backend, Linux adds `VM_PFNMAP` or `VM_MIXEDMAP` and
may update `vm_page_prot`. Those changes describe the installed PTEs and
must be retained by the real VMA.

For example, Linux v6.5's IOMMU mapping path can use `vm_map_pages()`, which
sets `VM_MIXEDMAP`. The current driver loses that bit. A live x86-64/IOMMU
check showed DMA mappings without any special-mapping flags.

## Change

- Mark the fixed-size DMA ring non-expandable and non-dumpable.
- Preserve the backend's flags and page protection on the original VMA.
- Preserve metadata even when a backend partially maps and then fails.
- Leave the original range/offset and the ARM DMA mapping mechanism intact.
- Use the appropriate flag API for kernels before and after v6.3.

This is a mapping-metadata correction. It is not a claim to solve every
DMA underrun, NUMA latency issue, or removal-lifetime problem.

## Validation

- Compile the actual driver mmap function against a narrow C DMA API mock.
  Cover TX/RX, PFN and mixed mappings, success and every partial-failure
  position, invalid size/offset, and both kernel flag APIs. The baseline
  fails the retained-metadata assertion; the patched code passes.
- Kernel module builds pass on Linux 6.5 and 6.8. The complete upstream
  driver with this patch also builds on 6.8.
- On the same x86-64/IOMMU setup, live mappings now expose `mm de dd` in
  `/proc/self/smaps`. CPU-only mapping checks and bounded checked DMA
  loopback tests pass. No ARM hardware qualification is claimed.
- The complete upstream test suite passes: 126 tests and 85 subtests
  (toolchain example builds excluded). Both GitHub CI jobs pass.

References: [Linux v6.5 IOMMU DMA mmap](https://github.com/torvalds/linux/blob/v6.5/drivers/iommu/dma-iommu.c),
[Linux v6.5 mapping helpers](https://github.com/torvalds/linux/blob/v6.5/mm/memory.c).
