### PR TITLE
phy/us: report the correct bus-master-enable status bit

### DIFF
--- a/litepcie/phy/uspciephy.py
+++ b/litepcie/phy/uspciephy.py
@@ -198,7 +198,7 @@ class USPCIEPHY(LiteXModule):
             self.id.eq(Cat(function_number, device_number, bus_number))
         ]
         self.comb += [
-            self._bus_master_enable.status.eq(cfg_function_status),
+            self._bus_master_enable.status.eq(cfg_function_status[2]),
             self._max_request_size.status.eq(self.max_request_size),
             self._max_payload_size.status.eq(self.max_payload_size),
         ]

--- a/litepcie/phy/usppciephy.py
+++ b/litepcie/phy/usppciephy.py
@@ -218,7 +218,7 @@ class USPPCIEPHY(LiteXModule):
             self.id.eq(Cat(function_number, device_number, bus_number))
         ]
         self.comb += [
-            self._bus_master_enable.status.eq(cfg_function_status),
+            self._bus_master_enable.status.eq(cfg_function_status[2]),
             self._max_request_size.status.eq(self.max_request_size),
             self._max_payload_size.status.eq(self.max_payload_size),
         ]

--- a/test/test_xilinx_pciephy.py
+++ b/test/test_xilinx_pciephy.py
@@ -7,7 +7,9 @@
 import unittest
 from types import SimpleNamespace
 
-from migen import Signal
+from migen import Module, Signal, run_simulation
+from migen.fhdl.structure import _Assign
+from migen.genlib.cdc import MultiReg
 
 from litepcie.phy.common     import get_bar_size_config
 from litepcie.phy.s7pciephy import S7PCIEPHY
@@ -42,6 +44,36 @@ class DummyPads:
 
 
 class TestXilinxPCIEPHY(unittest.TestCase):
+    def test_ultrascale_bus_master_status_uses_function_zero_bit_two(self):
+        for phy_cls, parameter_name in [
+            (USPCIEPHY, "pcie_phy_params"),
+            (USPPCIEPHY, "pcie_usp_phy_params"),
+        ]:
+            with self.subTest(phy=phy_cls.__name__):
+                phy = phy_cls(DummyPlatform(), DummyPads(4), data_width=128, pcie_data_width=128)
+                native = getattr(phy, parameter_name)["o_cfg_function_status"]
+                status = phy._bus_master_enable.status
+                # Simulate the production CSR/CDC path without vendor hard-IP primitives.
+                dut = Module()
+                assignments = [statement for statement in phy._fragment.comb
+                               if isinstance(statement, _Assign) and statement.l is status]
+                self.assertEqual(len(assignments), 1)
+                dut.comb += assignments
+                dut.specials += [special for special in phy._fragment.specials
+                                 if isinstance(special, MultiReg)]
+
+                def generator():
+                    values = [0, 1, 2, 4, 5, 7, 0xffff, 0xfffb, 0]
+                    values += [1 << bit for bit in range(16)]
+                    values += [0xffff ^ (1 << bit) for bit in range(16)]
+                    for value in values:
+                        yield native.eq(value)
+                        for _ in range(5):
+                            yield
+                        self.assertEqual((yield status), (value >> 2) & 1, hex(value))
+
+                run_simulation(dut, generator())
+
     def test_bar_size_config_is_exact(self):
         self.assertEqual(get_bar_size_config(        128), ("Bytes",      128))
         self.assertEqual(get_bar_size_config(     4*1024), ("Kilobytes",   4))


### PR DESCRIPTION
## Summary

Select bit 2 of `cfg_function_status` for the one-bit bus-master-enable CSR
in the UltraScale and UltraScale+ PHYs. Assigning the entire 16-bit status
to this CSR truncated it to bit 0, reporting function-zero I/O Space Enable
instead of Bus Master Enable.

This corrects diagnostic reporting only. It does not change requester
admission, PCIe configuration, DMA teardown or transaction draining.

The field layout is documented in the
[AMD PG213 Configuration Status Interface](https://docs.amd.com/r/en-US/pg213-pcie4-ultrascale-plus/Configuration-Status-Interface).

## Validation

- Simulate the production CSR assignment and synchronizers for both PHYs.
- Exercise independent I/O, memory and bus-master bits, other functions,
  walking ones, walking zeros, and enable/disable transitions.
- The new regression fails on the old assignment in both PHYs.
- `pytest -q test/test_xilinx_pciephy.py`: six tests pass with the fix.

The test excludes vendor hard-IP primitives; this is not hardware DMA
quiescence qualification.
