### PR TITLE
ptm: Keep packet classification off the filter FIFO data path

### DIFF
--- a/litepcie/frontend/ptm/sniffer.py
+++ b/litepcie/frontend/ptm/sniffer.py
@@ -453,6 +453,9 @@ class TLPFilterFormater(LiteXModule):
             reverse          = False
         )
         self.comb += [
+            # Data is sampled only when valid/ready assert. Keep the packet
+            # classifier off the FIFO data path; it already controls writes.
+            fifo.sink.dat.eq(sink.data),
             fifo.sink.be.eq(0b1111),
             fifo.source.connect(conv.sink),
             conv.source.connect(self.source),
@@ -465,13 +468,11 @@ class TLPFilterFormater(LiteXModule):
                 # PTM Request.
                 If(sink.data[24:32] == fmt_type_dict["ptm_req"],
                     fifo.sink.valid.eq(1),
-                    fifo.sink.dat.eq(sink.data),
                     NextValue(count, 3 - 1), # 3DWs Header.
                     NextState("RECEIVE")
                 # PTM Response.
                 ).Elif(sink.data[24:32] == fmt_type_dict["ptm_res"],
                     fifo.sink.valid.eq(1),
-                    fifo.sink.dat.eq(sink.data),
                     NextValue(count, 4 - 1), # 4DWs Header.
                     NextState("RECEIVE")
                 ).Else(
@@ -482,7 +483,6 @@ class TLPFilterFormater(LiteXModule):
         fsm.act("RECEIVE",
             If(sink.valid,
                 fifo.sink.valid.eq(1),
-                fifo.sink.dat.eq(sink.data),
                 NextValue(count, count - 1),
                 If(count == 0,
                     fifo.sink.last.eq(1),

--- a/test/test_ptm_filter.py
+++ b/test/test_ptm_filter.py
@@ -1,0 +1,66 @@
+"""PTM filtering preserves packet data through gaps and output backpressure."""
+import random
+
+from migen import run_simulation
+
+from litepcie.frontend.ptm.sniffer import TLPFilterFormater
+from litepcie.tlp.common import fmt_type_dict
+
+
+def test_ptm_filter_packets():
+    rng = random.Random(27)
+    dut = TLPFilterFormater()
+    packets = []
+    expected = []
+    for index in range(60):
+        kind = ('ptm_req', 'ptm_res', 'mem_rd32')[index % 3]
+        words = [(fmt_type_dict[kind] << 24) | rng.getrandbits(24)]
+        words += [rng.getrandbits(32) for _ in range(5 if kind == 'ptm_res' else 3)]
+        packets.append(words)
+        if kind != 'mem_rd32':
+            # The existing filter forwards four words for a request and five
+            # for a response, then waits for the physical packet end.
+            expected.append(words[:5] if kind == 'ptm_res' else words)
+    received = []
+
+    def stimulus():
+        for words in packets:
+            for index, word in enumerate(words):
+                for _ in range(rng.randrange(3)):
+                    yield dut.sink.valid.eq(0)
+                    yield dut.sink.data.eq(rng.getrandbits(32))
+                    yield
+                yield dut.sink.valid.eq(1)
+                yield dut.sink.data.eq(word)
+                yield dut.sink.last.eq(index == len(words) - 1)
+                yield
+            yield dut.sink.valid.eq(0)
+            yield dut.sink.last.eq(0)
+            for _ in range(16):
+                yield dut.sink.data.eq(rng.getrandbits(32))
+                yield
+        for _ in range(20):
+            yield
+
+    def observe():
+        packet = []
+        for cycle in range(2200):
+            yield dut.source.ready.eq(cycle % 5 != 0)
+            if (yield dut.source.valid) and (yield dut.source.ready):
+                data = (yield dut.source.dat)
+                be = (yield dut.source.be)
+                for word in range(2):
+                    if (be >> (4 * word)) & 15:
+                        packet.append((data >> (32 * word)) & 0xffffffff)
+                if (yield dut.source.last):
+                    # The 64-bit converter pads the odd five-word response.
+                    # Its upper final word is not part of the PTM message.
+                    if packet[0] >> 24 == fmt_type_dict["ptm_res"]:
+                        assert len(packet) == 6
+                        packet = packet[:5]
+                    received.append(packet)
+                    packet = []
+            yield
+
+    run_simulation(dut, [stimulus(), observe()])
+    assert received == expected


### PR DESCRIPTION
The PTM filter assigned FIFO data only inside its packet classification states. This placed classification/valid logic on both the FIFO write-enable and data paths; a complete upstream WR build on SPEC-A7 exposed a six-LUT path into the FIFO data input.

Drive FIFO data directly from the input and retain the existing valid/ready handshake to control writes. Accepted data and cycle timing are unchanged.

Validation:

- The packet regression covers PTM requests/responses, unrelated packets, idle gaps and output backpressure.
- A comparison against the original implementation matched every valid output field cycle by cycle over 12,000 randomized cycles (602 valid cycles, 451 accepted cycles).
- Clean Vivado 2024.1 Acorn and SPEC-A7 WR builds using this change meet final setup/hold timing: Acorn +0.174/+0.036 ns; SPEC +0.045/+0.057 ns. The SPEC build also uses the documented placement settings; placement optimization alone had still missed timing before the data-path correction.
- Both GitHub CI checks pass. The rebuilt boards passed 30 minutes in each WR direction and twelve recovery tests over USB UART/JTAG. PCIe traffic was not exercised on this bench.

[Full upstream WR build findings](https://github.com/enjoy-digital/litex_wr_nic/blob/wr-link-qualification/doc/wr_link/upstream-build.md) and [timing reports, tests and hardware evidence](https://github.com/enjoy-digital/litex_wr_nic/blob/wr-link-qualification/doc/wr_link/results-upstream/README.md) are included in enjoy-digital/litex_wr_nic#84.
